### PR TITLE
Performance improvement for collection cells with many childs (1000+)

### DIFF
--- a/core/kernel/source/jetbrains/mps/util/CachedIndexList.java
+++ b/core/kernel/source/jetbrains/mps/util/CachedIndexList.java
@@ -1,0 +1,263 @@
+/*
+ * Copyright 2013 Sascha Lisson.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.mps.util;
+
+import org.jetbrains.annotations.NotNull;
+
+import java.util.Collection;
+import java.util.HashMap;
+import java.util.Iterator;
+import java.util.List;
+import java.util.ListIterator;
+import java.util.Map;
+
+/**
+ * A List wrapper with a fast implementation for indexOf(Object). Not thread-safe.
+ * User: Sascha Lisson
+ * Date: 2013-12-10
+ */
+public class CachedIndexList<E> implements List<E> {
+
+  private List<E> myDelegate;
+  private Map<E, Integer> myCache = new HashMap<E, Integer>();
+  private boolean myCacheValid = false;
+
+  public CachedIndexList(List<E> delegate) {
+    myDelegate = delegate;
+  }
+
+  protected void updateCache() {
+    myCache.clear();
+    int index = -1;
+    for (E e : myDelegate) {
+      myCache.put(e, ++index);
+    }
+    myCacheValid = true;
+  }
+
+  @Override
+  public int size() {
+    return myDelegate.size();
+  }
+
+  @Override
+  public boolean isEmpty() {
+    return myDelegate.isEmpty();
+  }
+
+  @Override
+  public boolean contains(Object o) {
+    return myDelegate.contains(o);
+  }
+
+  @NotNull
+  @Override
+  public Iterator<E> iterator() {
+    return new IteratorWrapper<E>(myDelegate.iterator());
+  }
+
+  @NotNull
+  @Override
+  public Object[] toArray() {
+    return myDelegate.toArray();
+  }
+
+  @NotNull
+  @Override
+  public <T> T[] toArray(T[] a) {
+    return myDelegate.toArray(a);
+  }
+
+  @Override
+  public boolean add(E e) {
+    myCacheValid = false;
+    return myDelegate.add(e);
+  }
+
+  @Override
+  public boolean remove(Object o) {
+    myCacheValid = false;
+    return myDelegate.remove(o);
+  }
+
+  @Override
+  public boolean containsAll(Collection<?> c) {
+    return myDelegate.containsAll(c);
+  }
+
+  @Override
+  public boolean addAll(Collection<? extends E> c) {
+    myCacheValid = false;
+    return myDelegate.addAll(c);
+  }
+
+  @Override
+  public boolean addAll(int index, Collection<? extends E> c) {
+    myCacheValid = false;
+    return myDelegate.addAll(index, c);
+  }
+
+  @Override
+  public boolean removeAll(Collection<?> c) {
+    myCacheValid = false;
+    return myDelegate.removeAll(c);
+  }
+
+  @Override
+  public boolean retainAll(Collection<?> c) {
+    myCacheValid = false;
+    return myDelegate.retainAll(c);
+  }
+
+  @Override
+  public void clear() {
+    myCacheValid = false;
+    myDelegate.clear();
+  }
+
+  @Override
+  public E get(int index) {
+    return myDelegate.get(index);
+  }
+
+  @Override
+  public E set(int index, E element) {
+    myCacheValid = false;
+    return myDelegate.set(index, element);
+  }
+
+  @Override
+  public void add(int index, E element) {
+    myCacheValid = false;
+    myDelegate.add(index, element);
+  }
+
+  @Override
+  public E remove(int index) {
+    myCacheValid = false;
+    return myDelegate.remove(index);
+  }
+
+  @Override
+  public int indexOf(Object o) {
+    if (!myCacheValid) updateCache();
+    Integer index = myCache.get(o);
+    return index == null ? -1 : index;
+  }
+
+  @Override
+  public int lastIndexOf(Object o) {
+    return myDelegate.lastIndexOf(o);
+  }
+
+  @NotNull
+  @Override
+  public ListIterator<E> listIterator() {
+    return myDelegate.listIterator();
+  }
+
+  @NotNull
+  @Override
+  public ListIterator<E> listIterator(int index) {
+    return new ListIteratorWrapper<E>(myDelegate.listIterator(index));
+  }
+
+  @NotNull
+  @Override
+  public List<E> subList(int fromIndex, int toIndex) {
+    return myDelegate.subList(fromIndex, toIndex);
+  }
+
+  private class IteratorWrapper<E> implements Iterator<E> {
+    private Iterator<E> myWrappedIterator;
+
+    private IteratorWrapper(Iterator<E> iterator) {
+      myWrappedIterator = iterator;
+    }
+
+    @Override
+    public boolean hasNext() {
+      return myWrappedIterator.hasNext();
+    }
+
+    @Override
+    public E next() {
+      return myWrappedIterator.next();
+    }
+
+    @Override
+    public void remove() {
+      myCacheValid = false;
+      myWrappedIterator.remove();
+    }
+  }
+
+  private class ListIteratorWrapper<E> implements ListIterator<E> {
+    private ListIterator<E> myWrappedIterator;
+
+    private ListIteratorWrapper(ListIterator<E> iterator) {
+      myWrappedIterator = iterator;
+    }
+
+    @Override
+    public boolean hasNext() {
+      return myWrappedIterator.hasNext();
+    }
+
+    @Override
+    public E next() {
+      return myWrappedIterator.next();
+    }
+
+    @Override
+    public boolean hasPrevious() {
+      return myWrappedIterator.hasPrevious();
+    }
+
+    @Override
+    public E previous() {
+      return myWrappedIterator.previous();
+    }
+
+    @Override
+    public int nextIndex() {
+      return myWrappedIterator.nextIndex();
+    }
+
+    @Override
+    public int previousIndex() {
+      return myWrappedIterator.previousIndex();
+    }
+
+    @Override
+    public void remove() {
+      myCacheValid = false;
+      myWrappedIterator.remove();
+    }
+
+    @Override
+    public void set(E e) {
+      myCacheValid = false;
+      myWrappedIterator.set(e);
+    }
+
+    @Override
+    public void add(E e) {
+      myCacheValid = false;
+      myWrappedIterator.add(e);
+    }
+  }
+}

--- a/editor/editor-api/source/jetbrains/mps/openapi/editor/cells/CellTraversalUtil.java
+++ b/editor/editor-api/source/jetbrains/mps/openapi/editor/cells/CellTraversalUtil.java
@@ -46,12 +46,10 @@ public class CellTraversalUtil {
       return null;
     }
 
-    Iterator<EditorCell> cellIterator = forward ? parent.iterator() : parent.reverseIterator();
-
-    while (cellIterator.hasNext()) {
-      if (cellIterator.next().equals(cell) && cellIterator.hasNext()) {
-        return cellIterator.next();
-      }
+    int index = parent.indexOf(cell);
+    int siblingIndex = forward ? index + 1 : index - 1;
+    if (0 <= siblingIndex && siblingIndex < parent.getCellsCount()) {
+      return parent.getCellAt(siblingIndex);
     }
 
     return null;

--- a/editor/editor-api/source/jetbrains/mps/openapi/editor/cells/EditorCell.java
+++ b/editor/editor-api/source/jetbrains/mps/openapi/editor/cells/EditorCell.java
@@ -20,6 +20,7 @@ import jetbrains.mps.openapi.editor.EditorContext;
 import jetbrains.mps.openapi.editor.TextBuilder;
 import jetbrains.mps.openapi.editor.message.SimpleEditorMessage;
 import jetbrains.mps.openapi.editor.style.Style;
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.mps.openapi.model.SNode;
 
 import java.util.Collection;
@@ -90,6 +91,9 @@ public interface EditorCell {
   void setRole(String role);
 
   String getRole();
+
+  @Nullable
+  String getPropertyName();
 
   boolean isErrorState();
 

--- a/editor/editor-runtime/source/jetbrains/mps/nodeEditor/cells/EditorCell_Basic.java
+++ b/editor/editor-runtime/source/jetbrains/mps/nodeEditor/cells/EditorCell_Basic.java
@@ -51,6 +51,7 @@ import jetbrains.mps.util.IterableUtil;
 import jetbrains.mps.util.ListMap;
 import jetbrains.mps.util.NameUtil;
 import org.apache.log4j.LogManager;
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.mps.openapi.model.SNode;
 import org.jetbrains.mps.openapi.model.SNodeReference;
 import org.jetbrains.mps.openapi.model.SNodeUtil;
@@ -369,6 +370,12 @@ public abstract class EditorCell_Basic implements EditorCell {
       return role;
     }
     return myRole;
+  }
+
+  @Nullable
+  @Override
+  public String getPropertyName() {
+    return null;
   }
 
   @Override

--- a/editor/editor-runtime/source/jetbrains/mps/nodeEditor/cells/EditorCell_Collection.java
+++ b/editor/editor-runtime/source/jetbrains/mps/nodeEditor/cells/EditorCell_Collection.java
@@ -42,6 +42,7 @@ import jetbrains.mps.openapi.editor.selection.Selection;
 import jetbrains.mps.openapi.editor.selection.SelectionListener;
 import jetbrains.mps.openapi.editor.style.Style;
 import jetbrains.mps.util.ArrayWrapper;
+import jetbrains.mps.util.CachedIndexList;
 import jetbrains.mps.util.NameUtil;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.mps.openapi.model.SNode;
@@ -72,7 +73,7 @@ public class EditorCell_Collection extends EditorCell_Basic implements jetbrains
   private static final EditorCell[] EMPTY_ARRAY = new EditorCell[0];
 
   private EditorCell[] myEditorCells = EditorCell_Collection.EMPTY_ARRAY;
-  private List<EditorCell> myEditorCellsWrapper = new ArrayWrapper<EditorCell>() {
+  private List<EditorCell> myEditorCellsWrapper = new CachedIndexList<EditorCell>(new ArrayWrapper<EditorCell>() {
     @Override
     protected EditorCell[] getArray() {
       return myEditorCells;
@@ -87,7 +88,7 @@ public class EditorCell_Collection extends EditorCell_Basic implements jetbrains
     protected EditorCell[] newArray(int size) {
       return new EditorCell[size];
     }
-  };
+  });
 
   private List<EditorCell> myFoldedCellCollection;
   private EditorCell myFoldedCell;

--- a/editor/editor-runtime/source/jetbrains/mps/nodeEditor/cells/EditorCell_Property.java
+++ b/editor/editor-runtime/source/jetbrains/mps/nodeEditor/cells/EditorCell_Property.java
@@ -23,6 +23,7 @@ import jetbrains.mps.smodel.NodeReadAccessCasterInEditor;
 import jetbrains.mps.smodel.NodeReadAccessInEditorListener;
 import jetbrains.mps.util.Computable;
 import jetbrains.mps.util.Pair;
+import org.jetbrains.annotations.Nullable;
 import org.jetbrains.mps.openapi.model.SNode;
 import org.jetbrains.mps.openapi.model.SNodeReference;
 
@@ -66,6 +67,12 @@ public class EditorCell_Property extends EditorCell_Label {
     String text = myModelAccessor.getText();
     setErrorState(!isValidText(text));
     setText(text);
+  }
+
+  @Nullable
+  @Override
+  public String getPropertyName() {
+    return myModelAccessor instanceof PropertyAccessor ? ((PropertyAccessor)myModelAccessor).getPropertyName() : null;
   }
 
   @Override

--- a/editor/editor-runtime/source/jetbrains/mps/nodeEditor/messageTargets/CellFinder.java
+++ b/editor/editor-runtime/source/jetbrains/mps/nodeEditor/messageTargets/CellFinder.java
@@ -63,11 +63,7 @@ public class CellFinder {
     EditorCell child = CellFinderUtil.findChildByCondition(rawCell, new Condition<EditorCell>() {
       @Override
       public boolean met(EditorCell cell) {
-        if (!(cell instanceof EditorCell_Property)) return false;
-        EditorCell_Property propertyCell = (EditorCell_Property) cell;
-        ModelAccessor modelAccessor = propertyCell.getModelAccessor();
-        return modelAccessor instanceof PropertyAccessor && node == propertyCell.getSNode()
-            && name.equals(((PropertyAccessor) modelAccessor).getPropertyName());
+        return  node == cell.getSNode() && name.equals(cell.getPropertyName());
       }
     }, true, true);
     if (child != null) {


### PR DESCRIPTION
In my mps-multiline language (https://github.com/slisson/mps-multiline)  I create a cell for each word. If the text contains 1000+ words and therefore the collection cell of the text has the same amount of childs, the editor performance is bad.

Luckily, it's not a big problem and can be fixed very easily. Here is my proposed solution.
