### PR TITLE
build: do not append '/' to the path

### DIFF
--- a/plugins/mps-build/languages/build/source_gen/jetbrains/mps/build/util/RelativePathHelper.java
+++ b/plugins/mps-build/languages/build/source_gen/jetbrains/mps/build/util/RelativePathHelper.java
@@ -16,7 +16,7 @@ public class RelativePathHelper {
     }
     String normalized = FileUtil.getAbsolutePath(fullPath).replace("\\", "/");
     try {
-      return FileUtil.getRelativePath(normalized, (myBasePath.endsWith("/") ? myBasePath : myBasePath + "/"), "/");
+      return FileUtil.getRelativePath(normalized, myBasePath, "/");
     } catch (Exception ex) {
       throw new RelativePathHelper.PathException(ex, ex.getMessage());
     }

--- a/plugins/mps-build/languages/build/utilModels/jetbrains/mps/buildScript/util.mps
+++ b/plugins/mps-build/languages/build/utilModels/jetbrains/mps/buildScript/util.mps
@@ -31,8 +31,8 @@
     <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language()" />
     <import index="pjrh" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.smodel.adapter()" />
-    <import index="tpce" ref="r:00000000-0000-4000-0000-011c89590292(jetbrains.mps.lang.structure.structure)" implicit="true" />
     <import index="arit" ref="r:0d66e868-9778-4307-b6f9-4795c00f662f(jetbrains.mps.build.workflow.preset.general)" implicit="true" />
+    <import index="tpce" ref="r:00000000-0000-4000-0000-011c89590292(jetbrains.mps.lang.structure.structure)" implicit="true" />
   </imports>
   <registry>
     <language id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples">
@@ -3998,29 +3998,8 @@
                 <node concept="37vLTw" id="3GM_nagTyWX" role="37wK5m">
                   <ref role="3cqZAo" node="1AfwOXhIBBY" resolve="normalized" />
                 </node>
-                <node concept="3K4zz7" id="1GLxzJyd_Tn" role="37wK5m">
-                  <node concept="3cpWs3" id="1GLxzJydAv3" role="3K4GZi">
-                    <node concept="Xl_RD" id="1GLxzJydAvm" role="3uHU7w">
-                      <property role="Xl_RC" value="/" />
-                    </node>
-                    <node concept="37vLTw" id="1GLxzJydAg$" role="3uHU7B">
-                      <ref role="3cqZAo" node="5iAPpylX$pd" resolve="myBasePath" />
-                    </node>
-                  </node>
-                  <node concept="37vLTw" id="1GLxzJydA28" role="3K4E3e">
-                    <ref role="3cqZAo" node="5iAPpylX$pd" resolve="myBasePath" />
-                  </node>
-                  <node concept="2OqwBi" id="1GLxzJydyPd" role="3K4Cdx">
-                    <node concept="37vLTw" id="2BHiRxeuPFa" role="2Oq$k0">
-                      <ref role="3cqZAo" node="5iAPpylX$pd" resolve="myBasePath" />
-                    </node>
-                    <node concept="liA8E" id="1GLxzJyd_j$" role="2OqNvi">
-                      <ref role="37wK5l" to="wyt6:~String.endsWith(java.lang.String):boolean" resolve="endsWith" />
-                      <node concept="Xl_RD" id="1GLxzJyd_u3" role="37wK5m">
-                        <property role="Xl_RC" value="/" />
-                      </node>
-                    </node>
-                  </node>
+                <node concept="37vLTw" id="2HmEomsZdlY" role="37wK5m">
+                  <ref role="3cqZAo" node="5iAPpylX$pd" resolve="myBasePath" />
                 </node>
                 <node concept="Xl_RD" id="1AfwOXhIBBy" role="37wK5m">
                   <property role="Xl_RC" value="/" />


### PR DESCRIPTION
The `RelativePathHelper` appended a `/` to every path that was not ending with `/` this cause different behavior on Mac and Linux. While on Mac everything worked fine on Linux the generated xml war incorrect. 

On Linux it resulted in:

```
<zipfileset dir="${build.tmp}/customProcessors/copyModels/code-languages-com.lmsintl.accent.licensing-languages-com.lmsintl.accent.licensing.gen-generator-template" prefix="module/../generator/template"/>
<zipfileset dir="${build.tmp}/customProcessors/copyModels/code-languages-com.lmsintl.accent.licensing-languages-com.lmsintl.accent.licensing.gen-languageModels" prefix="module/../languageModels"/>
```

While on Mac it worked correctly:

```
<zipfileset dir="${build.tmp}/customProcessors/copyModels/code-languages-com.lmsintl.accent.licensing-languages-com.lmsintl.accent.licensing.gen-generator-template" prefix="module/generator/template"/>
<zipfileset dir="${build.tmp}/customProcessors/copyModels/code-languages-com.lmsintl.accent.licensing-languages-com.lmsintl.accent.licensing.gen-languageModels" prefix="module/languageModels"/>
```
