### PR TITLE
Stable hashing for LanguageScope

### DIFF
--- a/core/typesystemEngine/source/jetbrains/mps/newTypesystem/rules/LanguageScopeFactory.java
+++ b/core/typesystemEngine/source/jetbrains/mps/newTypesystem/rules/LanguageScopeFactory.java
@@ -156,9 +156,20 @@ public class LanguageScopeFactory {
   private static class LanguagesHolder extends IdentityWrapper<Iterable<SLanguage>> {
 
     private LanguageScope myLangScope = null;
+    private final int myHash;
 
     public LanguagesHolder(Iterable<SLanguage> langs)  {
       super(langs);
+      int tempHash = 0;
+      for (SLanguage lang : langs) {
+        tempHash ^= lang.getSourceModule().getModuleId().hashCode();
+      }
+      myHash = tempHash;
+    }
+
+    @Override
+    public int hashCode() {
+      return myHash;
     }
 
     public boolean hasScope () {


### PR DESCRIPTION
In order to make use of the `SimpleLRUCache` in `LanguageScopeFactory` the `LanguagesHolder` needs to provide a stable hashing function otherwise it will fall back to the default implementation in `IdentityWrapper`. As the default implementation simply calls down to `System.identityHashCode` which only return the same hashcode for the exact same object. 

If `getLanguageScope`is called from `LanguageScopeExecutor.execWithModelScope` the `SModelOperations.getAllLanguageImports`returns a new `HashSet` instance on every invocation we will get a different HashCode for each of them.

I now implemented the `hashCode` function (naive) based on the source module Ids. Which gave us much better cache hits. We did this change because we spotted the `getLanguageScope` call as a hotspot during our generation. We were able to improve the performance of `SimpleTypecheckingContext.getTypeOf_generationMode` by around 30% starting from the second call for the same model. Since our generation heavily depends on the type calculated in the typesystem we got some noticeable improvements there.