### PR TITLE
Fix Condition in New Roottemplate intention

### DIFF
--- a/languages/languageDesign/generator/languages/templateLanguage/languageModels/intentions.mps
+++ b/languages/languageDesign/generator/languages/templateLanguage/languageModels/intentions.mps
@@ -2364,8 +2364,15 @@
                   </node>
                 </node>
                 <node concept="3cpWs6" id="7S2IGmHMbl1" role="3cqZAp">
-                  <node concept="3clFbT" id="7S2IGmHMbl2" role="3cqZAk">
-                    <property role="3clFbU" value="true" />
+                  <node concept="2OqwBi" id="4iqie86iR3m" role="3cqZAk">
+                    <node concept="37vLTw" id="4iqie86iQo_" role="2Oq$k0">
+                      <ref role="3cqZAo" node="7S2IGmHMbl3" resolve="c" />
+                    </node>
+                    <node concept="2Zo12i" id="4iqie86iRF7" role="2OqNvi">
+                      <node concept="chp4Y" id="4iqie86iS1q" role="2Zo12j">
+                        <ref role="cht4Q" to="tpck:h0TrEE$" resolve="INamedConcept" />
+                      </node>
+                    </node>
                   </node>
                 </node>
               </node>

--- a/languages/languageDesign/generator/languages/templateLanguage/source_gen.caches/jetbrains/mps/lang/generator/intentions/generated
+++ b/languages/languageDesign/generator/languages/templateLanguage/source_gen.caches/jetbrains/mps/lang/generator/intentions/generated
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<dependencies version="2" modelHash="-5sq9jdr2h4szv0c8kp9mbeac5npa6y5" />
+<dependencies version="2" modelHash="dhfqhgsuhcx3pbzcqeidgtwaizvvfjr" />
 

--- a/languages/languageDesign/generator/languages/templateLanguage/source_gen/jetbrains/mps/lang/generator/intentions/NewTemplateInRootMappingRule_Intention.java
+++ b/languages/languageDesign/generator/languages/templateLanguage/source_gen/jetbrains/mps/lang/generator/intentions/NewTemplateInRootMappingRule_Intention.java
@@ -97,7 +97,7 @@ public final class NewTemplateInRootMappingRule_Intention extends IntentionDescr
           if (SConceptOperations.isExactly(SNodeOperations.asSConcept(c), MetaAdapterFactory.getConcept(0xb401a68083254110L, 0x8fd384331ff25befL, 0x1165958fcd6L, "jetbrains.mps.lang.generator.structure.MappingScript"))) {
             return false;
           }
-          return true;
+          return SConceptOperations.isSubConceptOf(SNodeOperations.asSConcept(c), MetaAdapterFactory.getInterfaceConcept(0xceab519525ea4f22L, 0x9b92103b95ca8c0cL, 0x110396eaaa4L, "jetbrains.mps.lang.core.structure.INamedConcept"));
         }
       });
     }

--- a/languages/languageDesign/generator/languages/templateLanguage/source_gen/jetbrains/mps/lang/generator/intentions/trace.info
+++ b/languages/languageDesign/generator/languages/templateLanguage/source_gen/jetbrains/mps/lang/generator/intentions/trace.info
@@ -835,7 +835,7 @@
       <node id="9080025156919276843" at="91,227,92,25" concept="8" />
       <node id="9080025156919276851" at="94,226,95,25" concept="8" />
       <node id="9080025156919276859" at="97,221,98,25" concept="8" />
-      <node id="9080025156919276865" at="99,11,100,22" concept="8" />
+      <node id="9080025156919276865" at="99,11,100,231" concept="8" />
       <node id="1216334426557" at="105,48,106,57" concept="8" />
       <node id="1216334426557" at="61,0,63,0" concept="1" trace="IntentionImplementation#()V" />
       <node id="1216334426557" at="33,0,36,0" concept="1" trace="NewTemplateInRootMappingRule_Intention#()V" />
@@ -900,7 +900,7 @@
       <scope id="9080025156919276869" at="75,0,86,0">
         <var name="root" id="9080025156919276869" />
       </scope>
-      <scope id="9080025156919276832" at="87,40,100,22" />
+      <scope id="9080025156919276832" at="87,40,100,231" />
       <scope id="9080025156919276831" at="87,0,102,0">
         <var name="c" id="9080025156919276831" />
       </scope>


### PR DESCRIPTION
The filter passed to `showCreateNewRootMenu` from the "New Root Template" intention did only filter out some generator concepts but the Root Mapping rule can only reference to instances if `INamedConcept` it makes little sense to show theses concepts in the intention menu because the implementation will directly return and do nothing then it detects that the root node is not `INamedConcept`.

As `reduce_TemplateInvocation` template calls later in the generator require a `INamedConcept` anyway I think we shouldn't show them to the user in that menu.
