### PR TITLE
Use character instead of one-character string where available

### DIFF
--- a/MPSPlugin/source/jetbrains/mps/plugin/CollectJUnitTestsFromPatternsAction.java
+++ b/MPSPlugin/source/jetbrains/mps/plugin/CollectJUnitTestsFromPatternsAction.java
@@ -147,7 +147,7 @@ public class CollectJUnitTestsFromPatternsAction extends AnAction {
         StringBuilder sb = new StringBuilder("@SuiteClassSymbols({");
         String sep = "";
         for (String sc : suiteClasses) {
-          sb.append(sep).append("\"").append(sc).append("\"");
+          sb.append(sep).append('\"').append(sc).append('\"');
           sep = ",\n";
         }
         sb.append("})");
@@ -265,7 +265,7 @@ public class CollectJUnitTestsFromPatternsAction extends AnAction {
       }
 
       String modulePtn = "";
-      int si = ptn.indexOf(":");
+      int si = ptn.indexOf(':');
       if (si >= 0) {
         modulePtn = ptn.substring(0, si);
         ptn = ptn.substring(si + 1);

--- a/MPSPlugin/source/jetbrains/mps/plugin/OpenGeneratedQueriesSourceInMPS.java
+++ b/MPSPlugin/source/jetbrains/mps/plugin/OpenGeneratedQueriesSourceInMPS.java
@@ -68,7 +68,7 @@ public class OpenGeneratedQueriesSourceInMPS extends AnAction {
   private void openSource(Project project, String namespace, String name) {
     ProjectHandler projectHandler = project.getComponent(ProjectHandler.class);
 
-    int lastUnderscore = name.lastIndexOf("_");
+    int lastUnderscore = name.lastIndexOf('_');
 
     if (lastUnderscore == -1 || lastUnderscore > name.length() - 1) return;
     String id = name.substring(lastUnderscore + 1);

--- a/core/generator/source/jetbrains/mps/generator/impl/dependencies/GenerationDependencies.java
+++ b/core/generator/source/jetbrains/mps/generator/impl/dependencies/GenerationDependencies.java
@@ -134,12 +134,12 @@ public class GenerationDependencies {
     Arrays.sort(keys);
     for (String key : keys) {
       sb.append("-------------------------\n");
-      sb.append(key).append("\n");
+      sb.append(key).append('\n');
       String val = myDependenciesTraces.get(key);
       for (String s : val.split("\n")) {
-        sb.append("\t\t").append(s).append("\n");
+        sb.append("\t\t").append(s).append('\n');
       }
-      sb.append("\n");
+      sb.append('\n');
     }
     myDependenciesTraces = null;
     return sb.toString();

--- a/core/generator/source/jetbrains/mps/generator/impl/plan/ConnectedComponentPartitioner.java
+++ b/core/generator/source/jetbrains/mps/generator/impl/plan/ConnectedComponentPartitioner.java
@@ -154,9 +154,9 @@ public class ConnectedComponentPartitioner {
     StringBuffer sb = new StringBuffer();
     sb.append(myRoots.length).append(" roots, ").append(partitions.length).append(" components\n");
     for (int i = 0; i < partitions.length; i++) {
-      sb.append("#").append(i).append("(").append(partitions[i].length).append("): ");
+      sb.append('#').append(i).append('(').append(partitions[i].length).append("): ");
       for (int e = 0; e < partitions[i].length; e++) {
-        sb.append(" ").append(myRoots[partitions[i][e]]);
+        sb.append(' ').append(myRoots[partitions[i][e]]);
       }
       sb.append('\n');
     }

--- a/core/kernel/dataFlowRuntime/source/jetbrains/mps/lang/dataFlow/framework/AnalysisResult.java
+++ b/core/kernel/dataFlowRuntime/source/jetbrains/mps/lang/dataFlow/framework/AnalysisResult.java
@@ -54,9 +54,9 @@ public class AnalysisResult<E> {
     StringBuilder r = new StringBuilder();
     for (int i = 0; i < myProgram.size(); i++) {
       Instruction instruction = myProgram.get(i);
-      r.append(instruction).append(" ");
+      r.append(instruction).append(' ');
       r.append(toString(myInstructionsResult.get(instruction)));
-      r.append("\n");
+      r.append('\n');
     }
     return r.toString();
   }

--- a/core/kernel/dataFlowRuntime/source/jetbrains/mps/lang/dataFlow/framework/Program.java
+++ b/core/kernel/dataFlowRuntime/source/jetbrains/mps/lang/dataFlow/framework/Program.java
@@ -325,9 +325,9 @@ public class Program {
     for (Instruction instruction : myInstructions) {
       result.append(instruction);
       if (instruction.getSource() != null && showSource) {
-        result.append(" ").append(instruction.getSource());
+        result.append(' ').append(instruction.getSource());
       }
-      result.append("\n");
+      result.append('\n');
     }
     return result.toString();
   }

--- a/core/kernel/source/jetbrains/mps/reloading/CompositeClassPathItem.java
+++ b/core/kernel/source/jetbrains/mps/reloading/CompositeClassPathItem.java
@@ -171,11 +171,11 @@ public class CompositeClassPathItem extends AbstractClassPathItem {
 
     for (IClassPathItem child : myChildren) {
       for (String s : child.toString().split("/[\n]/")) {
-        result.append('\t').append(s).append("\n");
+        result.append('\t').append(s).append('\n');
       }
     }
 
-    result.append("}");
+    result.append('}');
     return result.toString();
   }
 }

--- a/core/kernel/source/jetbrains/mps/smodel/SModelReference.java
+++ b/core/kernel/source/jetbrains/mps/smodel/SModelReference.java
@@ -344,7 +344,7 @@ public final class SModelReference implements org.jetbrains.mps.openapi.model.SM
 
     if (getModuleReference() != null && getModuleReference().getModuleId() != null) {
       sb.append(StringUtil.escapeRefChars(getModuleReference().getModuleId().toString()));
-      sb.append("/");
+      sb.append('/');
     }
 
     String modelId = myModelId instanceof ModelNameSModelId ? myModelId.getModelName() : myModelId.toString();
@@ -354,16 +354,16 @@ public final class SModelReference implements org.jetbrains.mps.openapi.model.SM
       return sb.toString();
     }
 
-    sb.append("(");
+    sb.append('(');
     if (getModuleReference() != null && getModuleReference().getModuleName() != null) {
       sb.append(StringUtil.escapeRefChars(getModuleReference().getModuleName()));
-      sb.append("/");
+      sb.append('/');
     }
     if (!myModelName.getValue().equals(myModelId.getModelName())) {
       // no reason to write down model name if it's part of module id
       sb.append(StringUtil.escapeRefChars(myModelName.getValue()));
     }
-    sb.append(")");
+    sb.append(')');
     return sb.toString();
   }
 

--- a/core/kernel/source/jetbrains/mps/smodel/language/LanguageAspectSupport.java
+++ b/core/kernel/source/jetbrains/mps/smodel/language/LanguageAspectSupport.java
@@ -105,7 +105,7 @@ public class LanguageAspectSupport {
   }
 
   public static boolean isLanguageModelNameForbidden(String modelName) {
-    String shortName = modelName.substring(modelName.lastIndexOf(".") + 1);
+    String shortName = modelName.substring(modelName.lastIndexOf('.') + 1);
     for (LanguageAspect aspect : LanguageAspect.values()) {
       if (shortName.equals(aspect.getName())) {
         return true;

--- a/core/kernel/source/jetbrains/mps/util/Macros.java
+++ b/core/kernel/source/jetbrains/mps/util/Macros.java
@@ -44,7 +44,7 @@ class Macros {
     if (!MacrosFactory.containsMacro(path)) {
       return path;
     }
-    String macro = path.substring(2, path.indexOf("}"));
+    String macro = path.substring(2, path.indexOf('}'));
     String relativePath = removePrefix(path);
     String macroValue = PATH_MACROS.getValue(macro);
     if (macroValue != null) {
@@ -89,7 +89,7 @@ class Macros {
   }
 
   String removePrefix(String path) {
-    String result = path.substring(path.indexOf("}") + 1);
+    String result = path.substring(path.indexOf('}') + 1);
     if (result.startsWith(File.separator)) {
       result = result.substring(1);
     }

--- a/core/kernel/source/jetbrains/mps/util/PatternUtil.java
+++ b/core/kernel/source/jetbrains/mps/util/PatternUtil.java
@@ -80,7 +80,7 @@ public class PatternUtil {
       return State.NO_QUOTING;
     } else if (c == '?') {
       if (useStarAndQuestionMark) {
-        b.append(".");
+        b.append('.');
       } else {
         b.append("\\?");
       }

--- a/core/kernel/source/jetbrains/mps/util/performance/PerformanceTracer.java
+++ b/core/kernel/source/jetbrains/mps/util/performance/PerformanceTracer.java
@@ -104,13 +104,13 @@ public class PerformanceTracer implements IPerformanceTracer {
       myStack[0].task.tasks.addAll(myStack[0].children.values());
       myStack[0].task.merge(new HashSet<>(Arrays.asList(separate)));
       StringBuilder sb = new StringBuilder();
-      sb.append("[");
+      sb.append('[');
       sb.append(traceName);
       sb.append("]\n");
       myStack[0].task.toString(sb, 0);
       for (String s : externalText) {
         sb.append(s);
-        sb.append("\n");
+        sb.append('\n');
       }
       return sb.toString();
     } else {
@@ -201,7 +201,7 @@ public class PerformanceTracer implements IPerformanceTracer {
           sb.append((executionTime - correction) / 1000000.);
           sb.append(" ms)");
         }
-        sb.append("\n");
+        sb.append('\n');
       }
       Collections.sort(tasks);
       for (Task t : tasks) {

--- a/core/make-runtime/source/jetbrains/mps/make/ModuleSources.java
+++ b/core/make-runtime/source/jetbrains/mps/make/ModuleSources.java
@@ -190,7 +190,7 @@ public class ModuleSources {
       if (childName.endsWith(MPSExtentions.DOT_CLASSFILE)) {
         boolean isInnerClass = false;
         String containerName = childName.substring(0, childName.length() - MPSExtentions.DOT_CLASSFILE.length());
-        int indexOfDollar = containerName.indexOf("$");
+        int indexOfDollar = containerName.indexOf('$');
         if (indexOfDollar > 0) {
           containerName = containerName.substring(0, indexOfDollar);
           isInnerClass = true;

--- a/core/make-runtime/source/jetbrains/mps/make/dependencies/graph/Graph.java
+++ b/core/make-runtime/source/jetbrains/mps/make/dependencies/graph/Graph.java
@@ -73,7 +73,7 @@ public class Graph<V extends IVertex> {
         }
         j++;
       }
-      sb.append("\n");
+      sb.append('\n');
     }
 
     return sb.toString();

--- a/core/persistence/source/jetbrains/mps/smodel/persistence/def/FilePerRootFormatUtil.java
+++ b/core/persistence/source/jetbrains/mps/smodel/persistence/def/FilePerRootFormatUtil.java
@@ -246,7 +246,7 @@ public class FilePerRootFormatUtil {
         case '>':
         case '|':
         case '#':
-          sb.append("_");
+          sb.append('_');
           continue;
       }
       sb.append((char) c);

--- a/core/project/source/jetbrains/mps/smodel/Generator.java
+++ b/core/project/source/jetbrains/mps/smodel/Generator.java
@@ -64,7 +64,7 @@ public class Generator extends ReloadableModuleBase {
   //models will be named like xxx.modelName, where xxx is a part of newName before sharp symbol
   @Override
   public void rename(@NotNull String newName) {
-    int sharp = newName.indexOf("#");
+    int sharp = newName.indexOf('#');
     newName = sharp < 0 ? newName : newName.substring(sharp);
     renameModels(getSourceLanguage().getModuleName(), newName, false);
 

--- a/core/smodel/source/jetbrains/mps/smodel/SNodePointer.java
+++ b/core/smodel/source/jetbrains/mps/smodel/SNodePointer.java
@@ -117,7 +117,7 @@ public class SNodePointer implements SNodeReference {
   }
 
   public static SNodeReference deserialize(String from) {
-    int delimiterIndex = from.lastIndexOf("/");
+    int delimiterIndex = from.lastIndexOf('/');
     String nodeId = StringUtil.unescapeRefChars(from.substring(delimiterIndex + 1));
     String modelReference = from.substring(0, delimiterIndex);
 

--- a/core/smodel/source/jetbrains/mps/smodel/StaticReference.java
+++ b/core/smodel/source/jetbrains/mps/smodel/StaticReference.java
@@ -128,7 +128,7 @@ public final class StaticReference extends SReferenceBase {
       sb.append("\nstack trace of model disposing is: ");
       for (StackTraceElement ste : ((ModelWithDisposeInfo) targetModel).getDisposedStacktrace()) {
         sb.append(ste);
-        sb.append("\n");
+        sb.append('\n');
       }
       log.error(sb.toString());
       log.errorWithTrace("=============current trace:=============");

--- a/core/smodel/source/jetbrains/mps/smodel/adapter/ids/SConceptId.java
+++ b/core/smodel/source/jetbrains/mps/smodel/adapter/ids/SConceptId.java
@@ -29,7 +29,7 @@ public final class SConceptId {
   }
 
   public static SConceptId deserialize(String s) {
-    int split = s.lastIndexOf("/");
+    int split = s.lastIndexOf('/');
     SLanguageId lang = SLanguageId.deserialize(s.substring(0, split));
     long concept = Long.parseLong(s.substring(split + 1));
     return new SConceptId(lang, concept);

--- a/core/smodel/source/jetbrains/mps/smodel/adapter/ids/SContainmentLinkId.java
+++ b/core/smodel/source/jetbrains/mps/smodel/adapter/ids/SContainmentLinkId.java
@@ -60,7 +60,7 @@ public final class SContainmentLinkId extends SConceptFeatureId {
   }
 
   public static SContainmentLinkId deserialize(String s) {
-    int split = s.lastIndexOf("/");
+    int split = s.lastIndexOf('/');
     SConceptId concept = SConceptId.deserialize(s.substring(0, split));
     long ref = Long.parseLong(s.substring(split + 1));
     return new SContainmentLinkId(concept, ref);

--- a/core/smodel/source/jetbrains/mps/smodel/adapter/ids/SPropertyId.java
+++ b/core/smodel/source/jetbrains/mps/smodel/adapter/ids/SPropertyId.java
@@ -54,7 +54,7 @@ public final class SPropertyId  extends SConceptFeatureId{
   }
 
   public static SPropertyId deserialize(String s) {
-    int split = s.lastIndexOf("/");
+    int split = s.lastIndexOf('/');
     SConceptId concept = SConceptId.deserialize(s.substring(0, split));
     long prop = Long.parseLong(s.substring(split + 1));
     return new SPropertyId(concept, prop);

--- a/core/smodel/source/jetbrains/mps/smodel/adapter/ids/SReferenceLinkId.java
+++ b/core/smodel/source/jetbrains/mps/smodel/adapter/ids/SReferenceLinkId.java
@@ -54,7 +54,7 @@ public final class SReferenceLinkId  extends SConceptFeatureId{
   }
 
   public static SReferenceLinkId deserialize(String s) {
-    int split = s.lastIndexOf("/");
+    int split = s.lastIndexOf('/');
     SConceptId concept = SConceptId.deserialize(s.substring(0, split));
     long ref = Long.parseLong(s.substring(split + 1));
     return new SReferenceLinkId(concept, ref);

--- a/core/typesystemEngine/source/jetbrains/mps/newTypesystem/state/blocks/Block.java
+++ b/core/typesystemEngine/source/jetbrains/mps/newTypesystem/state/blocks/Block.java
@@ -57,7 +57,7 @@ public abstract class Block {
       sb.append(var);
       sb.append(" is a type of ");
       sb.append(nodeMaps.getNode(var));
-      sb.append("\n");
+      sb.append('\n');
     }
     return sb.toString();
   }

--- a/core/util/source/jetbrains/mps/util/NameUtil.java
+++ b/core/util/source/jetbrains/mps/util/NameUtil.java
@@ -136,10 +136,10 @@ public class NameUtil {
     StringBuilder result = new StringBuilder(s.length());
     StringTokenizer st = new StringTokenizer(s);
 
-    if (s.startsWith(" ")) result.append(" ");
+    if (s.startsWith(" ")) result.append(' ');
 
     while (st.hasMoreTokens()) {
-      result.append(wordWithNamingPolicy(st.nextToken())).append(" ");
+      result.append(wordWithNamingPolicy(st.nextToken())).append(' ');
     }
 
     if (!s.endsWith(" ")) {
@@ -225,7 +225,7 @@ public class NameUtil {
     StringBuilder result = new StringBuilder(s.length());
     StringTokenizer st = new StringTokenizer(s);
     while (st.hasMoreTokens()) {
-      result.append(decapitalize(st.nextToken())).append(" ");
+      result.append(decapitalize(st.nextToken())).append(' ');
     }
     return result.substring(0, result.length() - 1);
   }

--- a/core/vfs/source/jetbrains/mps/util/FileUtil.java
+++ b/core/vfs/source/jetbrains/mps/util/FileUtil.java
@@ -385,7 +385,7 @@ public class FileUtil {
 
       String line;
       while ((line = r.readLine()) != null) {
-        result.append(line).append("\n");
+        result.append(line).append('\n');
       }
 
       return result.toString();

--- a/core/vfs/source/jetbrains/mps/util/URLUtil.java
+++ b/core/vfs/source/jetbrains/mps/util/URLUtil.java
@@ -69,7 +69,7 @@ public class URLUtil {
     assert file.indexOf(JAR_SEPARATOR) > 0;
 
     String resource = file.substring(file.indexOf(JAR_SEPARATOR) + 2);
-    file = file.substring(0, file.indexOf("!"));
+    file = file.substring(0, file.indexOf('!'));
     final ZipFile zipFile = new ZipFile(FileUtil.unquote(file));
     final ZipEntry zipEntry = zipFile.getEntry(resource);
     if (zipEntry == null) throw new FileNotFoundException("Entry " + resource + " not found in " + file);

--- a/core/vfs/source/jetbrains/mps/vfs/IFileUtils.java
+++ b/core/vfs/source/jetbrains/mps/vfs/IFileUtils.java
@@ -129,7 +129,7 @@ public class IFileUtils {
       while (br.ready()) {
         sb.append( br.readLine() );
         // FIXME preserve original line ednings
-        sb.append("\n");
+        sb.append('\n');
       }
       return sb.toString();
 

--- a/core/vfs/source/jetbrains/mps/vfs/impl/AbstractJarFileData.java
+++ b/core/vfs/source/jetbrains/mps/vfs/impl/AbstractJarFileData.java
@@ -52,7 +52,7 @@ class AbstractJarFileData {
   }
 
   String getParentDirectory(String dir) {
-    int lastSlash = dir.lastIndexOf("/");
+    int lastSlash = dir.lastIndexOf('/');
     if (lastSlash == -1) return "";
     return dir.substring(0, lastSlash);
   }

--- a/core/vfs/source/jetbrains/mps/vfs/impl/IoFileSystem.java
+++ b/core/vfs/source/jetbrains/mps/vfs/impl/IoFileSystem.java
@@ -44,7 +44,7 @@ public class IoFileSystem implements FileSystem {
     // fix for MPS-10350; todo move
     path = FileUtil.getCanonicalPath(path);
     if (path.contains("!")) {
-      int index = path.indexOf("!");
+      int index = path.indexOf('!');
       String jarPath = path.substring(0, index);
       String entryPath = FileUtil.getUnixPath(path.substring(index + 1));
 

--- a/core/vfs/source/jetbrains/mps/vfs/impl/JarFileData.java
+++ b/core/vfs/source/jetbrains/mps/vfs/impl/JarFileData.java
@@ -88,7 +88,7 @@ class JarFileData extends AbstractJarFileData {
 
   @Override
   String getParentDirectory(String dir) {
-    int lastSlash = dir.lastIndexOf("/");
+    int lastSlash = dir.lastIndexOf('/');
     if (lastSlash == -1) {
       return "";
     }

--- a/editor/editor-runtime/source/jetbrains/mps/nodeEditor/EditorComponent.java
+++ b/editor/editor-runtime/source/jetbrains/mps/nodeEditor/EditorComponent.java
@@ -1034,7 +1034,7 @@ public abstract class EditorComponent extends JComponent implements Scrollable, 
     for (ListIterator<HighlighterMessage> it = messages.listIterator(messages.size()); it.hasPrevious(); ) {
       SimpleEditorMessage message = it.previous();
       if (result.length() != 0) {
-        result.append("\n");
+        result.append('\n');
       }
       result.append(message.getMessage());
     }
@@ -1541,10 +1541,10 @@ public abstract class EditorComponent extends JComponent implements Scrollable, 
       sb.append("\nat ");
       sb.append(element);
     }
-    sb.append("\n");
+    sb.append('\n');
     sb.append("EditorComponent.myDisposed == ");
     sb.append(isDisposed());
-    sb.append("\n");
+    sb.append('\n');
     return sb.toString();
   }
 

--- a/editor/editor-runtime/source/jetbrains/mps/nodeEditor/MessagesGutter.java
+++ b/editor/editor-runtime/source/jetbrains/mps/nodeEditor/MessagesGutter.java
@@ -358,7 +358,7 @@ public class MessagesGutter extends ButtonlessScrollBarUI.Transparent implements
       StringBuilder text = new StringBuilder();
       for (GutterMark mark : gutterMarks) {
         if (text.length() > 0) {
-          text.append("\n");
+          text.append('\n');
         }
         text.append(mark.getEditorMessage().getMessage());
       }

--- a/editor/editor-runtime/source/jetbrains/mps/nodeEditor/SearchPanel.java
+++ b/editor/editor-runtime/source/jetbrains/mps/nodeEditor/SearchPanel.java
@@ -87,7 +87,7 @@ public class SearchPanel extends AbstractSearchPanel {
       List<EditorCell_Label> editorCell_labelList = CollectionUtil.filter(EditorCell_Label.class, collection.dfsCells());
       for (EditorCell_Label label : editorCell_labelList) {
         if (PunctuationUtil.hasLeftGap(label)) {
-          sb.append(" ");
+          sb.append(' ');
         }
         sb.append(label.getRenderedText());
       }

--- a/editor/editorlang-runtime/source/jetbrains/mps/editor/runtime/TextBuilderImpl.java
+++ b/editor/editorlang-runtime/source/jetbrains/mps/editor/runtime/TextBuilderImpl.java
@@ -102,7 +102,7 @@ public class TextBuilderImpl implements TextBuilder {
     while (builderIterator.hasNext()) {
       StringBuilder nextLine = new StringBuilder(newWidth);
       for (int i = 0; i < myWidth + delimWidth; i++) {
-        nextLine.append(" ");
+        nextLine.append(' ');
       }
       nextLine.append(builderIterator.next());
       myLines.add(nextLine);

--- a/plugins/mpsdevkit/source/jetbrains/mps/ide/devkit/cellExplorer/cellsTree/CellNode.java
+++ b/plugins/mpsdevkit/source/jetbrains/mps/ide/devkit/cellExplorer/cellsTree/CellNode.java
@@ -79,7 +79,7 @@ class CellNode extends MPSTreeNode {
 
     String text = getCellText();
     if (text != null) {
-      result.append(" \"").append(text).append("\"");
+      result.append(" \"").append(text).append('\"');
     }
     return result.toString();
   }

--- a/testbench/tests_gen/jetbrains/mps/testbench/ModuleGenerationHolder.java
+++ b/testbench/tests_gen/jetbrains/mps/testbench/ModuleGenerationHolder.java
@@ -147,7 +147,7 @@ public class ModuleGenerationHolder {
     if (MapSequence.fromMap(path2tmp).containsKey(path)) {
       return FileSystem.getInstance().getFileByPath(MapSequence.fromMap(path2tmp).get(path));
     }
-    int idx = path.indexOf("/");
+    int idx = path.indexOf('/');
     idx = (idx < 0 ? path.indexOf(File.separator) : idx);
     String tmp = tmpPath + "/" + ((idx < 0 ? path.replace(':', '_') : path.substring(idx + 1)));
     MapSequence.fromMap(path2tmp).put(path, tmp);

--- a/tools/deepcompare/src/jetbrains/mps/deepcompare/CompareStatus.java
+++ b/tools/deepcompare/src/jetbrains/mps/deepcompare/CompareStatus.java
@@ -48,7 +48,7 @@ public class CompareStatus {
     }
 
     public PrintWriter stream(String streamId, String path) {
-        int slash = path.indexOf("/");
+        int slash = path.indexOf('/');
         if(slash == -1) {
             return stream(streamId);
         }

--- a/tools/deepcompare/src/jetbrains/mps/deepcompare/FolderCompare.java
+++ b/tools/deepcompare/src/jetbrains/mps/deepcompare/FolderCompare.java
@@ -88,7 +88,7 @@ public class FolderCompare {
     }
 
     private boolean isTextFile(String fileName) {
-        String extension = fileName.contains(".") ? fileName.substring(fileName.lastIndexOf(".") + 1).toLowerCase() : "";
+        String extension = fileName.contains(".") ? fileName.substring(fileName.lastIndexOf('.') + 1).toLowerCase() : "";
         return extension.equals("xml") || extension.equals("msd") || extension.equals("mpl") || extension.equals("mps")
                 || extension.equals("number") || extension.equals("java") || extension.equals("bat")
                 || extension.equals("sh") || fileName.equals("trace.info") || extension.equals("history")
@@ -288,7 +288,7 @@ public class FolderCompare {
 
             String line;
             while ((line = r.readLine()) != null) {
-                result.append(line).append("\n");
+                result.append(line).append('\n');
             }
 
             return result.toString();

--- a/tools/deepcompare/src/jetbrains/mps/deepcompare/ZipFoldersReporter.java
+++ b/tools/deepcompare/src/jetbrains/mps/deepcompare/ZipFoldersReporter.java
@@ -46,7 +46,7 @@ public class ZipFoldersReporter {
     }
 
     private static String parentFolder(String name) {
-        int i = name.lastIndexOf("/");
+        int i = name.lastIndexOf('/');
         if (i >= 0) {
             return name.substring(0, i);
         }

--- a/tools/tools/source/jetbrains/mps/excluded/ModuleNameFixer.java
+++ b/tools/tools/source/jetbrains/mps/excluded/ModuleNameFixer.java
@@ -110,6 +110,6 @@ public class ModuleNameFixer {
     }
 
     content = content.substring(content.indexOf(prefix) + prefix.length());
-    return content.substring(0, content.indexOf("\""));
+    return content.substring(0, content.indexOf('\"'));
   }
 }

--- a/tools/tools/source/jetbrains/mps/excluded/Utils.java
+++ b/tools/tools/source/jetbrains/mps/excluded/Utils.java
@@ -210,7 +210,7 @@ public class Utils {
     }
 
     private String removePrefix(String path) {
-      String result = path.substring(path.indexOf("}") + 1);
+      String result = path.substring(path.indexOf('}') + 1);
       if (result.startsWith(File.separator)) result = result.substring(1);
       return result;
     }

--- a/workbench/mps-platform/source/jetbrains/mps/ide/blame/dialog/BlameDialog.java
+++ b/workbench/mps-platform/source/jetbrains/mps/ide/blame/dialog/BlameDialog.java
@@ -268,7 +268,7 @@ public class BlameDialog extends DialogWrapper {
     builder.append("Build number: ''").append(ai.getBuild().asString()).append("''\n");
     builder.append("Version: ''").append(ai.getFullVersion()).append("''\n");
     if (myPluginDescriptor != null) {
-      builder.append("*[Plugin info]*").append("\n");
+      builder.append("*[Plugin info]*").append('\n');
       builder.append("Plugin id: ''").append(myPluginDescriptor.getPluginId()).append("''\n");
       if (myPluginDescriptor instanceof IdeaPluginDescriptor) {
         final IdeaPluginDescriptor pluginDescriptor = (IdeaPluginDescriptor) myPluginDescriptor;
@@ -310,12 +310,12 @@ public class BlameDialog extends DialogWrapper {
     }
 
     description.append(getAdditionalInfo());
-    description.append("\n");
+    description.append('\n');
 
     if (!myThrowableList.isEmpty()) {
       description.append("{code}");
       for (Throwable ex : myThrowableList) {
-        description.append(ex2str(ex)).append("\n");
+        description.append(ex2str(ex)).append('\n');
       }
       description.append("{code}");
     }

--- a/workbench/mps-platform/source/jetbrains/mps/ide/vfs/IdeaFile.java
+++ b/workbench/mps-platform/source/jetbrains/mps/ide/vfs/IdeaFile.java
@@ -385,7 +385,7 @@ public class IdeaFile implements IFileEx, CachingFile {
       }
     } else {
       if (myPath.contains("!")) {
-        return new IdeaFile(myFileSystem, myPath.substring(0, myPath.indexOf("!")));
+        return new IdeaFile(myFileSystem, myPath.substring(0, myPath.indexOf('!')));
       } else {
         return getParent();
       }
@@ -411,7 +411,7 @@ public class IdeaFile implements IFileEx, CachingFile {
   private static VirtualFile findIdeaFile(String path, boolean withRefresh) {
     LocalFileSystem localFileSystem = LocalFileSystem.getInstance();
     if (path.contains("!")) {
-      int index = path.indexOf("!");
+      int index = path.indexOf('!');
       String jarPath = path.substring(0, index);
       String entryPath = path.substring(index + 1);
 

--- a/workbench/mps-ui/source/jetbrains/mps/ide/messages/MessageList.java
+++ b/workbench/mps-ui/source/jetbrains/mps/ide/messages/MessageList.java
@@ -490,7 +490,7 @@ public abstract class MessageList implements IMessageList, SearchHistoryStorage,
       final StringBuilder sb = new StringBuilder();
       for (IMessage message : selectedValues) {
         sb.append(message.getText());
-        sb.append("\n");
+        sb.append('\n');
 
         if (message.getException() != null) {
           sb.append(ExceptionUtil.getThrowableText(message.getException()));

--- a/workbench/mps-workbench/source/jetbrains/mps/ide/java/JavaLexer.java
+++ b/workbench/mps-workbench/source/jetbrains/mps/ide/java/JavaLexer.java
@@ -453,7 +453,7 @@ public class JavaLexer extends LexerBase {
       String s;
       StringBuffer buf = new StringBuffer();
       while ((s = reader.readLine()) != null) {
-        buf.append(s).append("\n");
+        buf.append(s).append('\n');
       }
 
       JavaLexer lexer = new JavaLexer(true, true);

--- a/workbench/mps-workbench/source/jetbrains/mps/ide/projectPane/logicalview/ProjectPaneTree.java
+++ b/workbench/mps-workbench/source/jetbrains/mps/ide/projectPane/logicalview/ProjectPaneTree.java
@@ -336,7 +336,7 @@ public class ProjectPaneTree extends ProjectTree implements NodeChildrenProvider
                 }
                 basePack.append(firstPart);
                 if (!firstPart.isEmpty() && !secondPart.isEmpty()) {
-                  basePack.append(".");
+                  basePack.append('.');
                 }
                 basePack.append(secondPart);
                 result.add(new Pair<>(new jetbrains.mps.smodel.SNodePointer(node), basePack.toString()));

--- a/workbench/mps-workbench/source/jetbrains/mps/ide/typesystem/trace/PresentationUtil.java
+++ b/workbench/mps-workbench/source/jetbrains/mps/ide/typesystem/trace/PresentationUtil.java
@@ -47,7 +47,7 @@ public class PresentationUtil {
         sb.append(var);
         sb.append(" is a type of ");
         sb.append(getNodePresentation(editorComponent, node));
-        sb.append("\n");
+        sb.append('\n');
       }
     }
     return sb.toString();


### PR DESCRIPTION
There're several places where a "one-character" string is created to be passed to a method that accepts a character directly. This last version is normally faster (and has not the overhead of creating the String object).
In this commit, I replaced most usages (ignoring files signalled as generated) for String.indexOf, String.lastIndexOf and StringBuilder.append .
