### PR TITLE
prevent DependencyHelper from adding self reference to a model

### DIFF
--- a/languages/core/core/languageModels/intentions.mps
+++ b/languages/core/core/languageModels/intentions.mps
@@ -33,6 +33,7 @@
       <concept id="1194033889146" name="jetbrains.mps.lang.sharedConcepts.structure.ConceptFunctionParameter_editorContext" flags="nn" index="1XNTG" />
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1080223426719" name="jetbrains.mps.baseLanguage.structure.OrExpression" flags="nn" index="22lmx$" />
       <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
         <child id="1082485599096" name="statements" index="9aQI4" />
       </concept>
@@ -92,6 +93,7 @@
       </concept>
       <concept id="1068498886292" name="jetbrains.mps.baseLanguage.structure.ParameterDeclaration" flags="ir" index="37vLTG" />
       <concept id="1068498886294" name="jetbrains.mps.baseLanguage.structure.AssignmentExpression" flags="nn" index="37vLTI" />
+      <concept id="1225271283259" name="jetbrains.mps.baseLanguage.structure.NPEEqualsExpression" flags="nn" index="17R0WA" />
       <concept id="4972933694980447171" name="jetbrains.mps.baseLanguage.structure.BaseVariableDeclaration" flags="ng" index="19Szcq">
         <child id="5680397130376446158" name="type" index="1tU5fm" />
       </concept>
@@ -977,10 +979,23 @@
               <node concept="3clFbS" id="5zAj$bdv0FV" role="3clFbx">
                 <node concept="3N13vt" id="5zAj$bdv0FW" role="3cqZAp" />
               </node>
-              <node concept="3clFbC" id="5zAj$bdv0FX" role="3clFbw">
-                <node concept="10Nm6u" id="5zAj$bdv0FY" role="3uHU7w" />
-                <node concept="37vLTw" id="5zAj$bdv0FZ" role="3uHU7B">
-                  <ref role="3cqZAo" node="5zAj$bdv0FO" resolve="modelToImport" />
+              <node concept="22lmx$" id="3$LD7L$wpne" role="3clFbw">
+                <node concept="17R0WA" id="3$LD7L$wrr_" role="3uHU7w">
+                  <node concept="37vLTw" id="3$LD7L$wr_v" role="3uHU7w">
+                    <ref role="3cqZAo" node="5zAj$bdv0FO" resolve="modelToImport" />
+                  </node>
+                  <node concept="2OqwBi" id="3$LD7L$wq2L" role="3uHU7B">
+                    <node concept="37vLTw" id="3$LD7L$wpxc" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5zAj$bduWWN" resolve="myNode" />
+                    </node>
+                    <node concept="I4A8Y" id="3$LD7L$wqdb" role="2OqNvi" />
+                  </node>
+                </node>
+                <node concept="3clFbC" id="5zAj$bdv0FX" role="3uHU7B">
+                  <node concept="37vLTw" id="5zAj$bdv0FZ" role="3uHU7B">
+                    <ref role="3cqZAo" node="5zAj$bdv0FO" resolve="modelToImport" />
+                  </node>
+                  <node concept="10Nm6u" id="5zAj$bdv0FY" role="3uHU7w" />
                 </node>
               </node>
             </node>


### PR DESCRIPTION
In certain cases where a reference is out of scope the "Add depedency to reference target" could add self reference to a model. This self reference would cause the build to fail afterwards. I added a check to no include the model of the node with the reference.