### PR TITLE
Fixed selected node when moving closing parenthesis to the left with …

### DIFF
--- a/languages/baseLanguage/baseLanguage/languageModels/editor.mps
+++ b/languages/baseLanguage/baseLanguage/languageModels/editor.mps
@@ -21783,8 +21783,10 @@
             <node concept="37vLTw" id="2BHiRxgm8Cw" role="37wK5m">
               <ref role="3cqZAo" node="4c9ExjQoskU" resolve="expr" />
             </node>
-            <node concept="3clFbT" id="4c9ExjQoskT" role="37wK5m">
-              <property role="3clFbU" value="false" />
+            <node concept="3fqX7Q" id="xhlZ432jr7" role="37wK5m">
+              <node concept="37vLTw" id="xhlZ432k6v" role="3fr31v">
+                <ref role="3cqZAo" node="4c9ExjQoskY" resolve="toRight" />
+              </node>
             </node>
           </node>
         </node>

--- a/languages/baseLanguage/baseLanguage/source_gen.caches/jetbrains/mps/baseLanguage/editor/generated
+++ b/languages/baseLanguage/baseLanguage/source_gen.caches/jetbrains/mps/baseLanguage/editor/generated
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<dependencies version="2" modelHash="cvy0ngorbj9vxfkb3rpa66a643di2p8" />
+<dependencies version="2" modelHash="bhj5l37v5ykmckw0wsgb7u89948fjgn" />
 

--- a/languages/baseLanguage/baseLanguage/source_gen.caches/jetbrains/mps/baseLanguage/generated
+++ b/languages/baseLanguage/baseLanguage/source_gen.caches/jetbrains/mps/baseLanguage/generated
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<dependencies version="2" modelHash="c0n4plaosiq8c05nvgbg18cebrs58ta" />
+<dependencies version="2" modelHash="chigoq07lpf212u1ubfwlzawhodre0l" />
 

--- a/languages/baseLanguage/baseLanguage/source_gen/jetbrains/mps/baseLanguage/editor/EditorParenthesisUtil.java
+++ b/languages/baseLanguage/baseLanguage/source_gen/jetbrains/mps/baseLanguage/editor/EditorParenthesisUtil.java
@@ -86,7 +86,7 @@ public class EditorParenthesisUtil {
       SLinkOperations.setTarget(binOp, MetaAdapterFactory.getContainmentLink(0xf3061a5392264cc5L, 0xa443f952ceaf5816L, 0xfbdeb6fecfL, 0xfbdeb7a11cL, "leftExpression"), expr);
     }
     ParenthesisUtil.checkOperationWRTPriority(binOp);
-    selectNode(context, expr, false);
+    selectNode(context, expr, !(toRight));
   }
   public static SNode findRightmostOrLeftmostLeafExpression(SNode root, boolean rightmost) {
     if (!(SNodeOperations.isInstanceOf(root, MetaAdapterFactory.getInterfaceConcept(0xf3061a5392264cc5L, 0xa443f952ceaf5816L, 0x182da1771714863eL, "jetbrains.mps.baseLanguage.structure.IBinaryLike")))) {


### PR DESCRIPTION
…the ctrl+shift+vk_left keystroke. When moving the closing parenthesis to the left with the above keystroke, the selected node was the opening parenthesis, instead of the closing parenthesis. I fixed that by changing a boolean value in the "moveParenthesisToTheLeftOrRightInside" function.