### PR TITLE
test language: set focus correctly 

### DIFF
--- a/plugins/mps-testing/languages/languageDesign/test/languageModels/editor.mps
+++ b/plugins/mps-testing/languages/languageDesign/test/languageModels/editor.mps
@@ -426,6 +426,7 @@
         <ref role="1k5W1q" to="tpen:hFCSAw$" resolve="LeftParen" />
       </node>
       <node concept="3F0A7n" id="hBxM0lw" role="3EZMnx">
+        <property role="1cu_pB" value="2" />
         <ref role="1NtTu8" to="tpck:h0TrG11" resolve="name" />
         <ref role="1k5W1q" node="hGd_SRr" resolve="NodeAnnotation" />
         <ref role="1ERwB7" node="hG2S5d1" resolve="Annotation_Actions" />

--- a/plugins/mps-testing/languages/languageDesign/test/languageModels/intentions.mps
+++ b/plugins/mps-testing/languages/languageDesign/test/languageModels/intentions.mps
@@ -354,6 +354,9 @@
           <node concept="2OqwBi" id="hBxOoyw" role="3clFbG">
             <node concept="1OKiuA" id="385mdrYGIRT" role="2OqNvi">
               <node concept="1XNTG" id="hBxOtgu" role="lBI5i" />
+              <node concept="2B6iha" id="6Q2cACerpGF" role="lGT1i">
+                <property role="1lyBwo" value="firstEditable" />
+              </node>
             </node>
             <node concept="37vLTw" id="3GM_nagTrcH" role="2Oq$k0">
               <ref role="3cqZAo" node="hBxOnhi" resolve="newAnnotation" />

--- a/plugins/mps-testing/languages/languageDesign/test/source_gen.caches/jetbrains/mps/lang/test/editor/dependencies
+++ b/plugins/mps-testing/languages/languageDesign/test/source_gen.caches/jetbrains/mps/lang/test/editor/dependencies
@@ -3183,6 +3183,7 @@
     <classNode dependClassName="jetbrains.mps.baseLanguage.editor.BaseLanguageStyle_StyleSheet.LeftParenStyleClass" />
     <classNode dependClassName="jetbrains.mps.baseLanguage.editor.BaseLanguageStyle_StyleSheet.RightParenStyleClass" />
     <classNode dependClassName="jetbrains.mps.editor.runtime.impl.cellActions.CellAction_DeleteSPropertyOrNode" />
+    <classNode dependClassName="jetbrains.mps.editor.runtime.style.FocusPolicy" />
     <classNode dependClassName="jetbrains.mps.editor.runtime.style.Measure" />
     <classNode dependClassName="jetbrains.mps.editor.runtime.style.Padding" />
     <classNode dependClassName="jetbrains.mps.editor.runtime.style.StyleAttributes" />

--- a/plugins/mps-testing/languages/languageDesign/test/source_gen.caches/jetbrains/mps/lang/test/editor/generated
+++ b/plugins/mps-testing/languages/languageDesign/test/source_gen.caches/jetbrains/mps/lang/test/editor/generated
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<dependencies version="2" modelHash="-cf8c44zq1him99cmhgffi9tk58hew5o" />
+<dependencies version="2" modelHash="-b0bcywn3xlxv4hvpg79olp7arom6f54" />
 

--- a/plugins/mps-testing/languages/languageDesign/test/source_gen.caches/jetbrains/mps/lang/test/intentions/dependencies
+++ b/plugins/mps-testing/languages/languageDesign/test/source_gen.caches/jetbrains/mps/lang/test/intentions/dependencies
@@ -205,6 +205,7 @@
     <classNode dependClassName="jetbrains.mps.lang.smodel.generator.smodelAdapter.SNodeOperations" />
     <classNode dependClassName="jetbrains.mps.lang.test.behavior.NodesTestCase__BehaviorDescriptor" />
     <classNode dependClassName="jetbrains.mps.openapi.editor.EditorContext" />
+    <classNode dependClassName="jetbrains.mps.openapi.editor.selection.SelectionManager" />
     <classNode dependClassName="jetbrains.mps.openapi.intentions.IntentionDescriptor" />
     <classNode dependClassName="jetbrains.mps.openapi.intentions.IntentionExecutable" />
     <classNode dependClassName="jetbrains.mps.openapi.intentions.Kind" />

--- a/plugins/mps-testing/languages/languageDesign/test/source_gen.caches/jetbrains/mps/lang/test/intentions/generated
+++ b/plugins/mps-testing/languages/languageDesign/test/source_gen.caches/jetbrains/mps/lang/test/intentions/generated
@@ -1,3 +1,3 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<dependencies version="2" modelHash="32nq54aws9591pfb7bf44g7xxcsqr3h" />
+<dependencies version="2" modelHash="84et0u3ucyq4nfvn1ojp6j51bvmcp9v" />
 

--- a/plugins/mps-testing/languages/languageDesign/test/source_gen/jetbrains/mps/lang/test/editor/TestNodeAnnotation_EditorBuilder_a.java
+++ b/plugins/mps-testing/languages/languageDesign/test/source_gen/jetbrains/mps/lang/test/editor/TestNodeAnnotation_EditorBuilder_a.java
@@ -25,6 +25,7 @@ import jetbrains.mps.lang.test.editor.transformationTest_StyleSheet.NodeAnnotati
 import jetbrains.mps.editor.runtime.style.StyleAttributes;
 import jetbrains.mps.editor.runtime.style.Padding;
 import jetbrains.mps.editor.runtime.style.Measure;
+import jetbrains.mps.editor.runtime.style.FocusPolicy;
 import jetbrains.mps.nodeEditor.cellMenu.SPropertySubstituteInfo;
 import jetbrains.mps.lang.smodel.generator.smodelAdapter.SNodeOperations;
 import jetbrains.mps.lang.smodel.generator.smodelAdapter.AttributeOperations;
@@ -90,6 +91,9 @@ import jetbrains.mps.baseLanguage.editor.BaseLanguageStyle_StyleSheet.RightParen
       new NodeAnnotationStyleClass(getEditorContext(), getNode()).apply(style, editorCell);
       style.set(StyleAttributes.PADDING_RIGHT, new Padding(1.0, Measure.SPACES));
       editorCell.getStyle().putAll(style);
+      if (true) {
+        editorCell.getStyle().set(StyleAttributes.FOCUS_POLICY, FocusPolicy.FIRST_EDITABLE_CELL);
+      }
       Annotation_Actions.setCellActions(editorCell, myNode, getEditorContext());
       editorCell.setSubstituteInfo(new SPropertySubstituteInfo(editorCell, property));
       setCellContext(editorCell);

--- a/plugins/mps-testing/languages/languageDesign/test/source_gen/jetbrains/mps/lang/test/editor/trace.info
+++ b/plugins/mps-testing/languages/languageDesign/test/source_gen/jetbrains/mps/lang/test/editor/trace.info
@@ -345,117 +345,120 @@
       <unit id="1210673785657" at="10,0,15,0" name="jetbrains.mps.lang.test.editor.TestNodeAnnotation_Editor" />
     </file>
     <file name="TestNodeAnnotation_EditorBuilder_a.java">
-      <node id="1210673785657" at="44,98,45,19" concept="11" />
-      <node id="1210673785657" at="45,19,46,18" concept="2" />
-      <node id="1210673785657" at="51,26,52,18" concept="8" />
-      <node id="1210673785657" at="55,39,56,39" concept="8" />
-      <node id="1210673785657" at="59,50,60,122" concept="7" />
-      <node id="1210673785657" at="60,122,61,48" concept="2" />
-      <node id="1210673785657" at="61,48,62,28" concept="2" />
-      <node id="1210673785657" at="62,28,63,65" concept="2" />
-      <node id="1210673785657" at="63,65,64,57" concept="2" />
-      <node id="1210673785657" at="64,57,65,57" concept="2" />
-      <node id="1210673785657" at="65,57,66,67" concept="2" />
-      <node id="1210673785657" at="66,67,67,57" concept="2" />
-      <node id="1210673785657" at="67,57,68,22" concept="8" />
-      <node id="1210673794902" at="70,49,71,94" concept="7" />
-      <node id="1210673794902" at="71,94,72,47" concept="2" />
-      <node id="1210673794902" at="72,47,73,34" concept="7" />
-      <node id="1210673794902" at="73,34,74,84" concept="2" />
-      <node id="1210673794902" at="74,84,75,40" concept="2" />
-      <node id="1210673794902" at="75,40,76,34" concept="2" />
-      <node id="1210673794902" at="76,34,77,22" concept="8" />
-      <node id="1210673792352" at="79,49,80,39" concept="2" />
-      <node id="1210673792352" at="81,9,82,146" concept="7" />
-      <node id="1210673792352" at="82,146,83,76" concept="2" />
-      <node id="1210673792352" at="83,76,84,149" concept="7" />
-      <node id="1210673792352" at="84,149,85,45" concept="2" />
-      <node id="1210673792352" at="85,45,86,153" concept="2" />
-      <node id="1210673792352" at="86,153,87,157" concept="2" />
-      <node id="1210673792352" at="87,157,88,44" concept="2" />
-      <node id="1210673792352" at="88,44,89,36" concept="7" />
-      <node id="1210673792352" at="89,36,90,91" concept="2" />
-      <node id="1210673792352" at="90,91,91,81" concept="2" />
-      <node id="1210673792352" at="91,81,92,42" concept="2" />
-      <node id="1210673792352" at="92,42,93,80" concept="2" />
-      <node id="1210673792352" at="93,80,94,86" concept="2" />
-      <node id="1210673792352" at="94,86,95,33" concept="2" />
-      <node id="1210673792352" at="95,33,96,306" concept="7" />
-      <node id="1210673792352" at="98,41,99,118" concept="8" />
-      <node id="1210673792352" at="102,74,103,89" concept="7" />
-      <node id="1210673792352" at="103,89,104,145" concept="8" />
-      <node id="1210673792352" at="105,12,106,24" concept="8" />
-      <node id="1210673792352" at="107,15,108,40" concept="2" />
-      <node id="1210673841386" at="111,59,112,85" concept="7" />
-      <node id="1210673841386" at="112,85,113,93" concept="7" />
-      <node id="1210673841386" at="113,93,114,22" concept="8" />
-      <node id="1210673843483" at="116,49,117,94" concept="7" />
-      <node id="1210673843483" at="117,94,118,47" concept="2" />
-      <node id="1210673843483" at="118,47,119,34" concept="7" />
-      <node id="1210673843483" at="119,34,120,85" concept="2" />
-      <node id="1210673843483" at="120,85,121,40" concept="2" />
-      <node id="1210673843483" at="121,40,122,34" concept="2" />
-      <node id="1210673843483" at="122,34,123,22" concept="8" />
-      <node id="1210673785657" at="41,0,43,0" concept="3" trace="myNode" />
-      <node id="1210673785657" at="55,0,58,0" concept="6" trace="createCell#()Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
-      <node id="1210673792352" at="98,0,101,0" concept="6" trace="accept#(Lorg/jetbrains/mps/openapi/model/SNode;)Z" />
-      <node id="1210673785657" at="44,0,48,0" concept="1" trace="TestNodeAnnotation_EditorBuilder_a#(Ljetbrains/mps/openapi/editor/EditorContext;Lorg/jetbrains/mps/openapi/model/SNode;)V" />
-      <node id="1210673785657" at="49,0,54,0" concept="6" trace="getNode#()Lorg/jetbrains/mps/openapi/model/SNode;" />
-      <node id="1210673792352" at="96,306,101,9" concept="7" />
-      <node id="1210673792352" at="101,9,106,24" concept="5" />
-      <node id="1210673841386" at="111,0,116,0" concept="6" trace="createAttributedNodeCell_vitjmc_c0#()Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
-      <node id="1210673794902" at="70,0,79,0" concept="6" trace="createConstant_vitjmc_a0#()Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
-      <node id="1210673843483" at="116,0,125,0" concept="6" trace="createConstant_vitjmc_d0#()Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
-      <node id="1210673785657" at="59,0,70,0" concept="6" trace="createCollection_vitjmc_a#()Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
-      <node id="1210673792352" at="80,39,109,5" concept="12" />
-      <node id="1210673792352" at="79,0,111,0" concept="6" trace="createProperty_vitjmc_b0#()Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
-      <scope id="1210673785657" at="51,26,52,18" />
-      <scope id="1210673785657" at="55,39,56,39" />
-      <scope id="1210673792352" at="98,41,99,118" />
-      <scope id="1210673792352" at="107,15,108,40" />
-      <scope id="1210673785657" at="44,98,46,18" />
-      <scope id="1210673792352" at="102,74,104,145">
+      <node id="1210673785657" at="45,98,46,19" concept="11" />
+      <node id="1210673785657" at="46,19,47,18" concept="2" />
+      <node id="1210673785657" at="52,26,53,18" concept="8" />
+      <node id="1210673785657" at="56,39,57,39" concept="8" />
+      <node id="1210673785657" at="60,50,61,122" concept="7" />
+      <node id="1210673785657" at="61,122,62,48" concept="2" />
+      <node id="1210673785657" at="62,48,63,28" concept="2" />
+      <node id="1210673785657" at="63,28,64,65" concept="2" />
+      <node id="1210673785657" at="64,65,65,57" concept="2" />
+      <node id="1210673785657" at="65,57,66,57" concept="2" />
+      <node id="1210673785657" at="66,57,67,67" concept="2" />
+      <node id="1210673785657" at="67,67,68,57" concept="2" />
+      <node id="1210673785657" at="68,57,69,22" concept="8" />
+      <node id="1210673794902" at="71,49,72,94" concept="7" />
+      <node id="1210673794902" at="72,94,73,47" concept="2" />
+      <node id="1210673794902" at="73,47,74,34" concept="7" />
+      <node id="1210673794902" at="74,34,75,84" concept="2" />
+      <node id="1210673794902" at="75,84,76,40" concept="2" />
+      <node id="1210673794902" at="76,40,77,34" concept="2" />
+      <node id="1210673794902" at="77,34,78,22" concept="8" />
+      <node id="1210673792352" at="80,49,81,39" concept="2" />
+      <node id="1210673792352" at="82,9,83,146" concept="7" />
+      <node id="1210673792352" at="83,146,84,76" concept="2" />
+      <node id="1210673792352" at="84,76,85,149" concept="7" />
+      <node id="1210673792352" at="85,149,86,45" concept="2" />
+      <node id="1210673792352" at="86,45,87,153" concept="2" />
+      <node id="1210673792352" at="87,153,88,157" concept="2" />
+      <node id="1210673792352" at="88,157,89,44" concept="2" />
+      <node id="1210673792352" at="89,44,90,36" concept="7" />
+      <node id="1210673792352" at="90,36,91,91" concept="2" />
+      <node id="1210673792352" at="91,91,92,81" concept="2" />
+      <node id="1210673792352" at="92,81,93,42" concept="2" />
+      <node id="1210673792352" at="94,17,95,97" concept="2" />
+      <node id="1210673792352" at="96,7,97,80" concept="2" />
+      <node id="1210673792352" at="97,80,98,86" concept="2" />
+      <node id="1210673792352" at="98,86,99,33" concept="2" />
+      <node id="1210673792352" at="99,33,100,306" concept="7" />
+      <node id="1210673792352" at="102,41,103,118" concept="8" />
+      <node id="1210673792352" at="106,74,107,89" concept="7" />
+      <node id="1210673792352" at="107,89,108,145" concept="8" />
+      <node id="1210673792352" at="109,12,110,24" concept="8" />
+      <node id="1210673792352" at="111,15,112,40" concept="2" />
+      <node id="1210673841386" at="115,59,116,85" concept="7" />
+      <node id="1210673841386" at="116,85,117,93" concept="7" />
+      <node id="1210673841386" at="117,93,118,22" concept="8" />
+      <node id="1210673843483" at="120,49,121,94" concept="7" />
+      <node id="1210673843483" at="121,94,122,47" concept="2" />
+      <node id="1210673843483" at="122,47,123,34" concept="7" />
+      <node id="1210673843483" at="123,34,124,85" concept="2" />
+      <node id="1210673843483" at="124,85,125,40" concept="2" />
+      <node id="1210673843483" at="125,40,126,34" concept="2" />
+      <node id="1210673843483" at="126,34,127,22" concept="8" />
+      <node id="1210673785657" at="42,0,44,0" concept="3" trace="myNode" />
+      <node id="1210673785657" at="56,0,59,0" concept="6" trace="createCell#()Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
+      <node id="1210673792352" at="93,42,96,7" concept="5" />
+      <node id="1210673792352" at="102,0,105,0" concept="6" trace="accept#(Lorg/jetbrains/mps/openapi/model/SNode;)Z" />
+      <node id="1210673785657" at="45,0,49,0" concept="1" trace="TestNodeAnnotation_EditorBuilder_a#(Ljetbrains/mps/openapi/editor/EditorContext;Lorg/jetbrains/mps/openapi/model/SNode;)V" />
+      <node id="1210673785657" at="50,0,55,0" concept="6" trace="getNode#()Lorg/jetbrains/mps/openapi/model/SNode;" />
+      <node id="1210673792352" at="100,306,105,9" concept="7" />
+      <node id="1210673792352" at="105,9,110,24" concept="5" />
+      <node id="1210673841386" at="115,0,120,0" concept="6" trace="createAttributedNodeCell_vitjmc_c0#()Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
+      <node id="1210673794902" at="71,0,80,0" concept="6" trace="createConstant_vitjmc_a0#()Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
+      <node id="1210673843483" at="120,0,129,0" concept="6" trace="createConstant_vitjmc_d0#()Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
+      <node id="1210673785657" at="60,0,71,0" concept="6" trace="createCollection_vitjmc_a#()Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
+      <node id="1210673792352" at="81,39,113,5" concept="12" />
+      <node id="1210673792352" at="80,0,115,0" concept="6" trace="createProperty_vitjmc_b0#()Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
+      <scope id="1210673785657" at="52,26,53,18" />
+      <scope id="1210673785657" at="56,39,57,39" />
+      <scope id="1210673792352" at="94,17,95,97" />
+      <scope id="1210673792352" at="102,41,103,118" />
+      <scope id="1210673792352" at="111,15,112,40" />
+      <scope id="1210673785657" at="45,98,47,18" />
+      <scope id="1210673792352" at="106,74,108,145">
         <var name="manager" id="1210673792352" />
       </scope>
-      <scope id="1210673785657" at="55,0,58,0" />
-      <scope id="1210673792352" at="98,0,101,0">
+      <scope id="1210673785657" at="56,0,59,0" />
+      <scope id="1210673792352" at="102,0,105,0">
         <var name="it" id="1210673792352" />
       </scope>
-      <scope id="1210673841386" at="111,59,114,22">
+      <scope id="1210673841386" at="115,59,118,22">
         <var name="editorCell" id="1210673841386" />
         <var name="manager" id="1210673841386" />
       </scope>
-      <scope id="1210673785657" at="44,0,48,0">
+      <scope id="1210673785657" at="45,0,49,0">
         <var name="context" id="1210673785657" />
         <var name="node" id="1210673785657" />
       </scope>
-      <scope id="1210673785657" at="49,0,54,0" />
-      <scope id="1210673841386" at="111,0,116,0" />
-      <scope id="1210673794902" at="70,49,77,22">
+      <scope id="1210673785657" at="50,0,55,0" />
+      <scope id="1210673841386" at="115,0,120,0" />
+      <scope id="1210673794902" at="71,49,78,22">
         <var name="editorCell" id="1210673794902" />
         <var name="style" id="1210673794902" />
       </scope>
-      <scope id="1210673843483" at="116,49,123,22">
+      <scope id="1210673843483" at="120,49,127,22">
         <var name="editorCell" id="1210673843483" />
         <var name="style" id="1210673843483" />
       </scope>
-      <scope id="1210673785657" at="59,50,68,22">
+      <scope id="1210673785657" at="60,50,69,22">
         <var name="editorCell" id="1210673785657" />
       </scope>
-      <scope id="1210673794902" at="70,0,79,0" />
-      <scope id="1210673843483" at="116,0,125,0" />
-      <scope id="1210673785657" at="59,0,70,0" />
-      <scope id="1210673792352" at="81,9,106,24">
+      <scope id="1210673794902" at="71,0,80,0" />
+      <scope id="1210673843483" at="120,0,129,0" />
+      <scope id="1210673785657" at="60,0,71,0" />
+      <scope id="1210673792352" at="82,9,110,24">
         <var name="currentPropertyAttributes" id="1210673792352" />
         <var name="editorCell" id="1210673792352" />
         <var name="property" id="1210673792352" />
         <var name="propertyAttributes" id="1210673792352" />
         <var name="style" id="1210673792352" />
       </scope>
-      <scope id="1210673792352" at="79,49,109,5" />
-      <scope id="1210673792352" at="79,0,111,0" />
-      <unit id="1210673792352" at="97,102,101,7" name="jetbrains.mps.lang.test.editor.TestNodeAnnotation_EditorBuilder_a$1" />
-      <unit id="1210673785657" at="40,0,126,0" name="jetbrains.mps.lang.test.editor.TestNodeAnnotation_EditorBuilder_a" />
+      <scope id="1210673792352" at="80,49,113,5" />
+      <scope id="1210673792352" at="80,0,115,0" />
+      <unit id="1210673792352" at="101,102,105,7" name="jetbrains.mps.lang.test.editor.TestNodeAnnotation_EditorBuilder_a$1" />
+      <unit id="1210673785657" at="41,0,130,0" name="jetbrains.mps.lang.test.editor.TestNodeAnnotation_EditorBuilder_a" />
     </file>
   </root>
   <root nodeRef="r:00000000-0000-4000-0000-011c89590384(jetbrains.mps.lang.test.editor)/1210674543309">

--- a/plugins/mps-testing/languages/languageDesign/test/source_gen/jetbrains/mps/lang/test/intentions/AddTestAnnotation_Intention.java
+++ b/plugins/mps-testing/languages/languageDesign/test/source_gen/jetbrains/mps/lang/test/intentions/AddTestAnnotation_Intention.java
@@ -19,6 +19,7 @@ import jetbrains.mps.smodel.action.SNodeFactoryOperations;
 import jetbrains.mps.lang.smodel.generator.smodelAdapter.AttributeOperations;
 import jetbrains.mps.lang.smodel.generator.smodelAdapter.IAttributeDescriptor;
 import jetbrains.mps.editor.runtime.selection.SelectionUtil;
+import jetbrains.mps.openapi.editor.selection.SelectionManager;
 import jetbrains.mps.openapi.intentions.IntentionDescriptor;
 
 public final class AddTestAnnotation_Intention extends AbstractIntentionDescriptor implements IntentionFactory {
@@ -61,7 +62,7 @@ public final class AddTestAnnotation_Intention extends AbstractIntentionDescript
     public void execute(final SNode node, final EditorContext editorContext) {
       SNode newAnnotation = SNodeFactoryOperations.createNewNode(SNodeFactoryOperations.asInstanceConcept(MetaAdapterFactory.getConcept(0x8585453e6bfb4d80L, 0x98deb16074f1d86cL, 0x119e1c6609cL, "jetbrains.mps.lang.test.structure.TestNodeAnnotation")), null);
       AttributeOperations.setAttribute(node, new IAttributeDescriptor.NodeAttribute(MetaAdapterFactory.getConcept(0x8585453e6bfb4d80L, 0x98deb16074f1d86cL, 0x11e0d52da47L, "jetbrains.mps.lang.test.structure.INodeAnnotation")), newAnnotation);
-      SelectionUtil.selectNode(editorContext, newAnnotation);
+      SelectionUtil.selectCell(editorContext, newAnnotation, SelectionManager.FIRST_EDITABLE_CELL);
     }
     @Override
     public IntentionDescriptor getDescriptor() {

--- a/plugins/mps-testing/languages/languageDesign/test/source_gen/jetbrains/mps/lang/test/intentions/trace.info
+++ b/plugins/mps-testing/languages/languageDesign/test/source_gen/jetbrains/mps/lang/test/intentions/trace.info
@@ -21,73 +21,73 @@
   </root>
   <root nodeRef="r:00000000-0000-4000-0000-011c89590386(jetbrains.mps.lang.test.intentions)/1210673906861">
     <file name="AddTestAnnotation_Intention.java">
-      <node id="1210673906861" at="25,0,26,0" concept="3" trace="myCachedExecutable" />
-      <node id="1210673906861" at="26,40,27,143" concept="12" />
-      <node id="1210673906861" at="30,35,31,31" concept="8" />
-      <node id="1210673906861" at="35,53,36,19" concept="8" />
-      <node id="1210673906861" at="37,5,38,16" concept="8" />
-      <node id="1215604078224" at="40,91,41,268" concept="8" />
-      <node id="1210673906861" at="44,35,45,17" concept="8" />
-      <node id="1210673906861" at="48,37,49,133" concept="2" />
-      <node id="1210673906861" at="50,5,51,30" concept="8" />
-      <node id="1210673948048" at="57,87,58,41" concept="8" />
-      <node id="1210674410577" at="61,78,62,258" concept="7" />
-      <node id="1210674361648" at="62,258,63,242" concept="2" />
-      <node id="1210674415352" at="63,242,64,61" concept="2" />
-      <node id="1210673906861" at="67,48,68,46" concept="8" />
-      <node id="1210673906861" at="54,0,56,0" concept="1" trace="IntentionImplementation#()V" />
-      <node id="1210673906861" at="26,0,29,0" concept="1" trace="AddTestAnnotation_Intention#()V" />
-      <node id="1210673906861" at="34,84,37,5" concept="5" />
-      <node id="1210673906861" at="40,0,43,0" concept="6" trace="isApplicableToNode#(Lorg/jetbrains/mps/openapi/model/SNode;Ljetbrains/mps/openapi/editor/EditorContext;)Z" />
-      <node id="1210673906861" at="47,99,50,5" concept="5" />
-      <node id="1210673906861" at="29,0,33,0" concept="6" trace="getPresentation#()Ljava/lang/String;" />
-      <node id="1210673906861" at="43,0,47,0" concept="6" trace="isSurroundWith#()Z" />
-      <node id="1210673906861" at="56,0,60,0" concept="6" trace="getDescription#(Lorg/jetbrains/mps/openapi/model/SNode;Ljetbrains/mps/openapi/editor/EditorContext;)Ljava/lang/String;" />
-      <node id="1210673906861" at="66,0,70,0" concept="6" trace="getDescriptor#()Ljetbrains/mps/openapi/intentions/IntentionDescriptor;" />
-      <node id="1210673906861" at="47,0,53,0" concept="6" trace="instances#(Lorg/jetbrains/mps/openapi/model/SNode;Ljetbrains/mps/openapi/editor/EditorContext;)Ljava/util/Collection;" />
-      <node id="1210673906861" at="60,0,66,0" concept="6" trace="execute#(Lorg/jetbrains/mps/openapi/model/SNode;Ljetbrains/mps/openapi/editor/EditorContext;)V" />
-      <node id="1210673906861" at="33,0,40,0" concept="6" trace="isApplicable#(Lorg/jetbrains/mps/openapi/model/SNode;Ljetbrains/mps/openapi/editor/EditorContext;)Z" />
-      <scope id="1210673906861" at="54,38,54,38" />
-      <scope id="1210673906861" at="26,40,27,143" />
-      <scope id="1210673906861" at="30,35,31,31" />
-      <scope id="1210673906861" at="35,53,36,19" />
-      <scope id="1210674015604" at="40,91,41,268" />
-      <scope id="1210673906861" at="44,35,45,17" />
-      <scope id="1210673906861" at="48,37,49,133" />
-      <scope id="1210673906863" at="57,87,58,41" />
-      <scope id="1210673906861" at="67,48,68,46" />
-      <scope id="1210673906861" at="54,0,56,0" />
-      <scope id="1210673906861" at="26,0,29,0" />
-      <scope id="1210673906861" at="40,0,43,0">
+      <node id="1210673906861" at="26,0,27,0" concept="3" trace="myCachedExecutable" />
+      <node id="1210673906861" at="27,40,28,143" concept="12" />
+      <node id="1210673906861" at="31,35,32,31" concept="8" />
+      <node id="1210673906861" at="36,53,37,19" concept="8" />
+      <node id="1210673906861" at="38,5,39,16" concept="8" />
+      <node id="1215604078224" at="41,91,42,268" concept="8" />
+      <node id="1210673906861" at="45,35,46,17" concept="8" />
+      <node id="1210673906861" at="49,37,50,133" concept="2" />
+      <node id="1210673906861" at="51,5,52,30" concept="8" />
+      <node id="1210673948048" at="58,87,59,41" concept="8" />
+      <node id="1210674410577" at="62,78,63,258" concept="7" />
+      <node id="1210674361648" at="63,258,64,242" concept="2" />
+      <node id="1210674415352" at="64,242,65,99" concept="2" />
+      <node id="1210673906861" at="68,48,69,46" concept="8" />
+      <node id="1210673906861" at="55,0,57,0" concept="1" trace="IntentionImplementation#()V" />
+      <node id="1210673906861" at="27,0,30,0" concept="1" trace="AddTestAnnotation_Intention#()V" />
+      <node id="1210673906861" at="35,84,38,5" concept="5" />
+      <node id="1210673906861" at="41,0,44,0" concept="6" trace="isApplicableToNode#(Lorg/jetbrains/mps/openapi/model/SNode;Ljetbrains/mps/openapi/editor/EditorContext;)Z" />
+      <node id="1210673906861" at="48,99,51,5" concept="5" />
+      <node id="1210673906861" at="30,0,34,0" concept="6" trace="getPresentation#()Ljava/lang/String;" />
+      <node id="1210673906861" at="44,0,48,0" concept="6" trace="isSurroundWith#()Z" />
+      <node id="1210673906861" at="57,0,61,0" concept="6" trace="getDescription#(Lorg/jetbrains/mps/openapi/model/SNode;Ljetbrains/mps/openapi/editor/EditorContext;)Ljava/lang/String;" />
+      <node id="1210673906861" at="67,0,71,0" concept="6" trace="getDescriptor#()Ljetbrains/mps/openapi/intentions/IntentionDescriptor;" />
+      <node id="1210673906861" at="48,0,54,0" concept="6" trace="instances#(Lorg/jetbrains/mps/openapi/model/SNode;Ljetbrains/mps/openapi/editor/EditorContext;)Ljava/util/Collection;" />
+      <node id="1210673906861" at="61,0,67,0" concept="6" trace="execute#(Lorg/jetbrains/mps/openapi/model/SNode;Ljetbrains/mps/openapi/editor/EditorContext;)V" />
+      <node id="1210673906861" at="34,0,41,0" concept="6" trace="isApplicable#(Lorg/jetbrains/mps/openapi/model/SNode;Ljetbrains/mps/openapi/editor/EditorContext;)Z" />
+      <scope id="1210673906861" at="55,38,55,38" />
+      <scope id="1210673906861" at="27,40,28,143" />
+      <scope id="1210673906861" at="31,35,32,31" />
+      <scope id="1210673906861" at="36,53,37,19" />
+      <scope id="1210674015604" at="41,91,42,268" />
+      <scope id="1210673906861" at="45,35,46,17" />
+      <scope id="1210673906861" at="49,37,50,133" />
+      <scope id="1210673906863" at="58,87,59,41" />
+      <scope id="1210673906861" at="68,48,69,46" />
+      <scope id="1210673906861" at="55,0,57,0" />
+      <scope id="1210673906861" at="27,0,30,0" />
+      <scope id="1210673906861" at="41,0,44,0">
         <var name="editorContext" id="1210673906861" />
         <var name="node" id="1210673906861" />
       </scope>
-      <scope id="1210673906865" at="61,78,64,61">
+      <scope id="1210673906865" at="62,78,65,99">
         <var name="newAnnotation" id="1210674410578" />
       </scope>
-      <scope id="1210673906861" at="29,0,33,0" />
-      <scope id="1210673906861" at="34,84,38,16" />
-      <scope id="1210673906861" at="43,0,47,0" />
-      <scope id="1210673906861" at="47,99,51,30" />
-      <scope id="1210673906861" at="56,0,60,0">
+      <scope id="1210673906861" at="30,0,34,0" />
+      <scope id="1210673906861" at="35,84,39,16" />
+      <scope id="1210673906861" at="44,0,48,0" />
+      <scope id="1210673906861" at="48,99,52,30" />
+      <scope id="1210673906861" at="57,0,61,0">
         <var name="editorContext" id="1210673906861" />
         <var name="node" id="1210673906861" />
       </scope>
-      <scope id="1210673906861" at="66,0,70,0" />
-      <scope id="1210673906861" at="47,0,53,0">
+      <scope id="1210673906861" at="67,0,71,0" />
+      <scope id="1210673906861" at="48,0,54,0">
         <var name="context" id="1210673906861" />
         <var name="node" id="1210673906861" />
       </scope>
-      <scope id="1210673906861" at="60,0,66,0">
+      <scope id="1210673906861" at="61,0,67,0">
         <var name="editorContext" id="1210673906861" />
         <var name="node" id="1210673906861" />
       </scope>
-      <scope id="1210673906861" at="33,0,40,0">
+      <scope id="1210673906861" at="34,0,41,0">
         <var name="editorContext" id="1210673906861" />
         <var name="node" id="1210673906861" />
       </scope>
-      <unit id="1210673906861" at="53,0,71,0" name="jetbrains.mps.lang.test.intentions.AddTestAnnotation_Intention$IntentionImplementation" />
-      <unit id="1210673906861" at="24,0,72,0" name="jetbrains.mps.lang.test.intentions.AddTestAnnotation_Intention" />
+      <unit id="1210673906861" at="54,0,72,0" name="jetbrains.mps.lang.test.intentions.AddTestAnnotation_Intention$IntentionImplementation" />
+      <unit id="1210673906861" at="25,0,73,0" name="jetbrains.mps.lang.test.intentions.AddTestAnnotation_Intention" />
     </file>
   </root>
   <root nodeRef="r:00000000-0000-4000-0000-011c89590386(jetbrains.mps.lang.test.intentions)/1215604006108">


### PR DESCRIPTION
Previously the complete annotation was selecteded in the current editor
context this made it impossible to directly start typing after adding
the annotation. As the node annotation and the annontated node where
selected typing anything would cause MPS to override the node itself.

Added a attracts focus to the name cell of the TestNodeAnnotation and
changed the intention "Add Test Label Annotation" to select the first
editable cell in the current editor context.