### PR TITLE
GenPlanActiveStep searches for checkpoints within the branch of the active step

### DIFF
--- a/core/generator/source/jetbrains/mps/generator/ICompositeGenerationElement.java
+++ b/core/generator/source/jetbrains/mps/generator/ICompositeGenerationElement.java
@@ -1,0 +1,34 @@
+/*
+ * Copyright 2003-2018 JetBrains s.r.o.
+ *
+ * Licensed under the Apache License, Version 2.0 (the "License");
+ * you may not use this file except in compliance with the License.
+ * You may obtain a copy of the License at
+ *
+ * http://www.apache.org/licenses/LICENSE-2.0
+ *
+ * Unless required by applicable law or agreed to in writing, software
+ * distributed under the License is distributed on an "AS IS" BASIS,
+ * WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+ * See the License for the specific language governing permissions and
+ * limitations under the License.
+ */
+package jetbrains.mps.generator;
+
+import jetbrains.mps.generator.ModelGenerationPlan.Step;
+
+import java.util.List;
+
+/**
+ * Marks all build related elements that contain nested build steps.
+ */
+public interface ICompositeGenerationElement {
+
+  /**
+   * Returns the nested build steps of this composite build step.
+   *
+   * @return the nested build steps
+   */
+  List<Step> getSteps();
+
+}

--- a/core/generator/source/jetbrains/mps/generator/ModelGenerationPlan.java
+++ b/core/generator/source/jetbrains/mps/generator/ModelGenerationPlan.java
@@ -35,9 +35,7 @@ import java.util.List;
  * Is it a final breakdown of shall I treat list of TMC as a raw input and re-order them as appropriate?
  * evgeny, 1/12/12
  */
-public interface ModelGenerationPlan {
-
-  List<Step> getSteps();
+public interface ModelGenerationPlan extends ICompositeGenerationElement {
 
   Collection<TemplateModule> getGenerators();
 
@@ -152,17 +150,17 @@ public interface ModelGenerationPlan {
     }
   }
 
-  final class Fork implements Step {
+  final class Fork implements Step, ICompositeGenerationElement {
     private final List<Step> myBranch;
 
     public Fork(List<Step> branch) {
       myBranch = branch;
     }
 
-    public List<Step> getBranch() {
+    @Override
+    public List<Step> getSteps() {
       return myBranch;
     }
-
   }
 
   /**

--- a/core/generator/source/jetbrains/mps/generator/RigidGenerationPlan.java
+++ b/core/generator/source/jetbrains/mps/generator/RigidGenerationPlan.java
@@ -67,7 +67,7 @@ public class RigidGenerationPlan implements ModelGenerationPlan {
           }
         }
       } else if (p instanceof Fork) {
-        queue.addAll(((Fork) p).getBranch());
+        queue.addAll(((Fork) p).getSteps());
       }
     }
     return rv;

--- a/core/generator/source/jetbrains/mps/generator/impl/GenPlanActiveStep.java
+++ b/core/generator/source/jetbrains/mps/generator/impl/GenPlanActiveStep.java
@@ -15,6 +15,7 @@
  */
 package jetbrains.mps.generator.impl;
 
+import jetbrains.mps.generator.ICompositeGenerationElement;
 import jetbrains.mps.generator.ModelGenerationPlan;
 import jetbrains.mps.generator.ModelGenerationPlan.Checkpoint;
 import jetbrains.mps.generator.ModelGenerationPlan.Step;
@@ -85,7 +86,7 @@ final class GenPlanActiveStep {
    * 'Unexpected' means the plan doesn't account for nodes of that language. This doesn't make sense with custom generation plans
    * where we expect incomplete set of languages. However, in the future we may get smart enough to respect order and to complain about
    * scenarios when a language has been processed already (so that we introduce a loop into plan, A->B->C->A)
-   *
+   * <p>
    * XXX refactor this cumbersome and misguiding check (with hand-crafted GPs in mind)
    */
   Collection<SNode> selectUnexpectedNodes(Iterable<SNode> nodes) {
@@ -112,8 +113,9 @@ final class GenPlanActiveStep {
 
   @Nullable
   public Checkpoint getLastCheckpoint() {
+    final ICompositeGenerationElement container = getContainer(myStep, myPlan);
     Checkpoint lastSeen = null;
-    for (Step p : myPlan.getSteps()) {
+    for (Step p : container.getSteps()) {
       if (myStep.equals(p)) {
         break;
       }
@@ -126,7 +128,8 @@ final class GenPlanActiveStep {
 
   @Nullable
   public Checkpoint getNextCheckpoint() {
-    Iterator<Step> it = myPlan.getSteps().iterator();
+    final ICompositeGenerationElement container = getContainer(myStep, myPlan);
+    Iterator<Step> it = container.getSteps().iterator();
     while (it.hasNext()) {
       if (myStep.equals(it.next())) {
         break;
@@ -140,4 +143,19 @@ final class GenPlanActiveStep {
     }
     return null;
   }
+
+  private ICompositeGenerationElement getContainer(final Step sought, final ICompositeGenerationElement current) {
+    for (Step step : current.getSteps()) {
+      if (step.equals(sought)) {
+        return current;
+      } else if (step instanceof ICompositeGenerationElement) {
+        final ICompositeGenerationElement result = getContainer(sought, (ICompositeGenerationElement) step);
+        if (result != null) {
+          return result;
+        }
+      }
+    }
+    return null;
+  }
+
 }

--- a/core/generator/source/jetbrains/mps/generator/impl/GenPlanActiveStep.java
+++ b/core/generator/source/jetbrains/mps/generator/impl/GenPlanActiveStep.java
@@ -113,7 +113,13 @@ final class GenPlanActiveStep {
 
   @Nullable
   public Checkpoint getLastCheckpoint() {
-    final ICompositeGenerationElement container = getContainer(myStep, myPlan);
+    ICompositeGenerationElement container = getContainer(myStep, myPlan);
+    // the assumption would be that getContainer would never return null
+    // guard against the case if this would ever be violated
+    if (container == null) {
+      container = this.myPlan;
+    }
+
     Checkpoint lastSeen = null;
     for (Step p : container.getSteps()) {
       if (myStep.equals(p)) {
@@ -128,7 +134,13 @@ final class GenPlanActiveStep {
 
   @Nullable
   public Checkpoint getNextCheckpoint() {
-    final ICompositeGenerationElement container = getContainer(myStep, myPlan);
+    ICompositeGenerationElement container = getContainer(myStep, myPlan);
+    // the assumption would be that getContainer would never return null
+    // guard against the case if this would ever be violated
+    if (container == null) {
+      container = this.myPlan;
+    }
+    
     Iterator<Step> it = container.getSteps().iterator();
     while (it.hasNext()) {
       if (myStep.equals(it.next())) {

--- a/core/generator/source/jetbrains/mps/generator/impl/GenerationSession.java
+++ b/core/generator/source/jetbrains/mps/generator/impl/GenerationSession.java
@@ -352,7 +352,7 @@ class GenerationSession {
         // pair cloneTransient/changeModelReference deserves a dedicated utility
         bi.inputModel = cloneTransientModel(currInputModel);
         changeModelReference(bi.inputModel, createTransientModelReference(myMajorStep, myMinorStep + 100));
-        bi.branch = forkStep.getBranch();
+        bi.branch = forkStep.getSteps();
         bi.majorStepAtFork = myMajorStep;
         bi.minorStepAtFork = myMinorStep + 100;
         bi.actualStateCopyOfLastBitTransformStepMappings = new ArrayList<>(lastBigTransformStepMappings);


### PR DESCRIPTION
The old implementation did not handle forks correctly. This implementation now tries to find the checkpoints within the branch of the active step. 

Related issue: https://youtrack.jetbrains.com/issue/MPS-29490