### PR TITLE
Change method name 'messages' to 'setMessageHandler'

### DIFF
--- a/core/generator/source/jetbrains/mps/generator/GenerationFacade.java
+++ b/core/generator/source/jetbrains/mps/generator/GenerationFacade.java
@@ -34,7 +34,7 @@ import java.util.List;
 
 /**
  * Entry point to model transformation (aka generation) process. Populate with relevant context information:
- * {@link #messages(IMessageHandler)}  to receive generator messages (optional);
+ * {@link #setMessageHandler(IMessageHandler)}  to receive generator messages (optional);
  * {@link #transients(TransientModelsProvider)} where to keep transient models (mandatory);
  * {@link #taskHandler(GeneratorTaskListener)} get notified about progress (optional);
  * {@link #trace(TraceFacility)} to get trace events (optional);
@@ -96,7 +96,7 @@ public final class GenerationFacade {
    * @param messages destination of generator messages, or <code>null</code>
    * @return <code>this</code> for convenience
    */
-  public GenerationFacade messages(@Nullable IMessageHandler messages) {
+  public GenerationFacade setMessageHandler(@Nullable IMessageHandler messages) {
     myMessageHandler = messages == null ? IMessageHandler.NULL_HANDLER : messages;
     return this;
   }

--- a/core/generator/test/jetbrains/mps/generator/impl/plan/CheckpointModelTest.java
+++ b/core/generator/test/jetbrains/mps/generator/impl/plan/CheckpointModelTest.java
@@ -127,7 +127,7 @@ public class CheckpointModelTest implements EnvironmentAware {
     final TransientModelsProvider tmProvider = mpsProject.getComponent(TransientModelsProvider.class);
     // need write for process(x, model) to construct transient module, and need model read to run transformation
     GenerationStatus genStatus = new ModelAccessHelper(mpsProject.getRepository()).runWriteAction(() -> {
-      GenerationFacade genFacade = new GenerationFacade(mpsProject.getRepository(), opt).transients(tmProvider).messages(myGeneratorMessages);
+      GenerationFacade genFacade = new GenerationFacade(mpsProject.getRepository(), opt).transients(tmProvider).setMessageHandler(myGeneratorMessages);
       tmProvider.initCheckpointModule();
       GenerationStatus rv = genFacade.process(new EmptyProgressMonitor(), m);
       tmProvider.publishAll();
@@ -187,7 +187,7 @@ public class CheckpointModelTest implements EnvironmentAware {
     final TransientModelsProvider tmProvider = mpsProject.getComponent(TransientModelsProvider.class);
     // write lock - see above #createModelWithOneCheckpoint
     GenerationStatus genStatus = new ModelAccessHelper(mpsProject.getRepository()).runWriteAction(() -> {
-      GenerationFacade genFacade = new GenerationFacade(mpsProject.getRepository(), opt).transients(tmProvider).messages(myGeneratorMessages);
+      GenerationFacade genFacade = new GenerationFacade(mpsProject.getRepository(), opt).transients(tmProvider).setMessageHandler(myGeneratorMessages);
       tmProvider.initCheckpointModule();
       GenerationStatus rv = genFacade.process(new EmptyProgressMonitor(), m);
       tmProvider.publishAll();
@@ -254,14 +254,14 @@ public class CheckpointModelTest implements EnvironmentAware {
       OptionsBuilder optBuilder = GenerationOptions.getDefaults();
       GenerationOptions opt = optBuilder.customPlan(m1, plan).create();
       final TransientModelsProvider tmProvider = mpsProject.getComponent(TransientModelsProvider.class);
-      GenerationFacade genFacade = new GenerationFacade(mpsProject.getRepository(), opt).transients(tmProvider).messages(myGeneratorMessages);
+      GenerationFacade genFacade = new GenerationFacade(mpsProject.getRepository(), opt).transients(tmProvider).setMessageHandler(myGeneratorMessages);
       tmProvider.initCheckpointModule();
       genStatus[0] = genFacade.process(new EmptyProgressMonitor(), m1);
       tmProvider.publishAll();
       SModel m2 = resolve(mr2);
       // although could, don't want to put plan for m2 right along with plan for m1, want to have them separate
       opt = optBuilder.customPlan(m2, plan).create();
-      genFacade = new GenerationFacade(mpsProject.getRepository(), opt).transients(tmProvider).messages(myGeneratorMessages);
+      genFacade = new GenerationFacade(mpsProject.getRepository(), opt).transients(tmProvider).setMessageHandler(myGeneratorMessages);
       tmProvider.initCheckpointModule();
       genStatus[1] = genFacade.process(new EmptyProgressMonitor(), m2);
       tmProvider.publishAll();
@@ -380,7 +380,7 @@ public class CheckpointModelTest implements EnvironmentAware {
       final SModel m = resolve(PersistenceFacade.getInstance().createModelReference("r:05c2f926-57b0-4b6d-930c-1aabb187694d(jetbrains.mps.generator.crossmodel.sandbox.entrymodel1)"));
       GenerationOptions opt = GenerationOptions.getDefaults().customPlan(m, plan).create();
       final TransientModelsProvider tmProvider = mpsProject.getComponent(TransientModelsProvider.class);
-      GenerationFacade genFacade = new GenerationFacade(mpsProject.getRepository(), opt).transients(tmProvider).messages(myGeneratorMessages);
+      GenerationFacade genFacade = new GenerationFacade(mpsProject.getRepository(), opt).transients(tmProvider).setMessageHandler(myGeneratorMessages);
       tmProvider.initCheckpointModule(); // XXX there are no checkpoints in the plan, do I need this?
       GenerationStatus rv = genFacade.process(new EmptyProgressMonitor(), m);
       tmProvider.publishAll();

--- a/core/generator/test/jetbrains/mps/generator/test/GenerationTestBase.java
+++ b/core/generator/test/jetbrains/mps/generator/test/GenerationTestBase.java
@@ -79,7 +79,7 @@ public class GenerationTestBase {
     GenerationOptions options = GenerationOptions.getDefaults()
         .generateInParallel(false, 1)
         .strictMode(true).reporting(false, true, false, 2).create();
-    new GenerationFacade(repo, options).transients(new TransientModelsProvider(repo, null)).messages(msg).process(new EmptyProgressMonitor(), descr);
+    new GenerationFacade(repo, options).transients(new TransientModelsProvider(repo, null)).setMessageHandler(msg).process(new EmptyProgressMonitor(), descr);
 
 
     // Stage 2. Regenerate. Measure time.
@@ -88,7 +88,7 @@ public class GenerationTestBase {
         .generateInParallel(false, 1)
         .strictMode(true).reporting(false, true, false, 2).create();
     long start = System.nanoTime();
-    new GenerationFacade(repo, options).transients(new TransientModelsProvider(repo, null)).messages(msg).process(new EmptyProgressMonitor(), descr);
+    new GenerationFacade(repo, options).transients(new TransientModelsProvider(repo, null)).setMessageHandler(msg).process(new EmptyProgressMonitor(), descr);
     long singleThread = System.nanoTime() - start;
 
     // Stage 3. Regenerate in parallel
@@ -97,7 +97,7 @@ public class GenerationTestBase {
         .generateInParallel(true, threads)
         .strictMode(true).reporting(false, true, false, 2).create();
     start = System.nanoTime();
-    new GenerationFacade(repo, options).transients(new TransientModelsProvider(repo, null)).messages(msg).process(new EmptyProgressMonitor(), descr);
+    new GenerationFacade(repo, options).transients(new TransientModelsProvider(repo, null)).setMessageHandler(msg).process(new EmptyProgressMonitor(), descr);
     long severalThreads = System.nanoTime() - start;
 
     String prefix = myTestName.getMethodName();

--- a/languages/core/core/source_gen/jetbrains/mps/lang/core/plugin/Generate_Facet.java
+++ b/languages/core/core/source_gen/jetbrains/mps/lang/core/plugin/Generate_Facet.java
@@ -456,7 +456,7 @@ public class Generate_Facet extends IFacet.Stub {
                 projectRepo.getModelAccess().runReadAction(new Runnable() {
                   public void run() {
                     GenerationFacade genFacade = new GenerationFacade(projectRepo, Target_configure.vars(pa.global()).generationOptions().create());
-                    genFacade.transients(Target_configure.vars(pa.global()).transientModelsProvider()).messages(mh).taskHandler(taskHandler);
+                    genFacade.transients(Target_configure.vars(pa.global()).transientModelsProvider()).setMessageHandler(mh).taskHandler(taskHandler);
                     genFacade.process(progressMonitor.subTask(100), tasks);
                   }
                 });

--- a/plugins/mps-testing/languages/gentest.rt/source_gen/jetbrains/mps/lang/test/generator/rt/TransformHelper.java
+++ b/plugins/mps-testing/languages/gentest.rt/source_gen/jetbrains/mps/lang/test/generator/rt/TransformHelper.java
@@ -53,7 +53,7 @@ public final class TransformHelper {
         }
         GenerationFacade genFacade = new GenerationFacade(myRepository, optBuilder.create());
         final GenerationTaskRecorder<GeneratorTask> taskHandler = new GenerationTaskRecorder<GeneratorTask>(null);
-        genFacade.transients(myTransientsProvider).messages(myMessages).taskHandler(taskHandler);
+        genFacade.transients(myTransientsProvider).setMessageHandler(myMessages).taskHandler(taskHandler);
         genFacade.process(new EmptyProgressMonitor(), myInputModel);
         myGenOutcome = taskHandler.getAllRecorded().get(0);
       }


### PR DESCRIPTION
This class is used to represent GenerationFacade.  The method named 'messages' is to set a Message Handler. Thus, the method name 'setMessageHandler' is more intuitive than 'message'.