### PR TITLE
Change method name 'dump' to 'printEntries'

### DIFF
--- a/core/generator/source/jetbrains/mps/generator/impl/plan/PriorityGraph.java
+++ b/core/generator/source/jetbrains/mps/generator/impl/plan/PriorityGraph.java
@@ -368,7 +368,7 @@ class PriorityGraph {
     return myRulePriorityEntries.isEmpty();
   }
 
-  public void dump() {
+  public void printEntries() {
     for (Entry entry : myRulePriorityEntries) {
       System.out.println(entry);
     }


### PR DESCRIPTION
This class is used to represent PriorityGraph.  The method named 'dump' is to printEntries. Thus, the method name 'printEntries' is more intuitive than 'dump'.