### PR TITLE
Change method name 'describe' to 'createProblemDescription'

### DIFF
--- a/core/generator/source/jetbrains/mps/generator/impl/GeneratorUtil.java
+++ b/core/generator/source/jetbrains/mps/generator/impl/GeneratorUtil.java
@@ -55,7 +55,7 @@ public class GeneratorUtil {
     return new ProblemDescription(nr, String.format("was %s: %s", nodeRole, msg));
   }
 
-  public static ProblemDescription describe(@Nullable SNodeReference node, String nodeRole) {
+  public static ProblemDescription createProblemDescription(@Nullable SNodeReference node, String nodeRole) {
     String msg;
     if (node == null) {
       msg = String.format("was %s: <unknown node reference>", nodeRole);
@@ -68,7 +68,7 @@ public class GeneratorUtil {
     if (node == null) {
       return null;
     }
-    return describe(node, nodeRole);
+    return createProblemDescription(node, nodeRole);
   }
 
   public static ProblemDescription describeIfExists(SNode node, String nodeRole) {

--- a/core/generator/source/jetbrains/mps/generator/impl/TemplateExecutionEnvironmentImpl.java
+++ b/core/generator/source/jetbrains/mps/generator/impl/TemplateExecutionEnvironmentImpl.java
@@ -294,8 +294,8 @@ public class TemplateExecutionEnvironmentImpl implements TemplateExecutionEnviro
         myErrorReported = true;
         getLogger().error(callSite, myMessage,
                           GeneratorUtil.describeIfExists(context.getInput(), "input"),
-                          GeneratorUtil.describe(callSite, "call site"),
-                          GeneratorUtil.describe(getTemplateNode(), "template declaration"));
+                          GeneratorUtil.createProblemDescription(callSite, "call site"),
+                          GeneratorUtil.createProblemDescription(getTemplateNode(), "template declaration"));
       }
     }
     TemplateModel templateModel = generator.getGenerationPlan().getTemplateModel(templateDeclaration.getSourceModel());
@@ -362,8 +362,8 @@ public class TemplateExecutionEnvironmentImpl implements TemplateExecutionEnviro
       String msg = "%s not found: cannot apply template declaration, try to check & regenerate affected generators";
       getLogger().error(templateNode, String.format(msg, templateModel == null ? "template model" : "declaration"),
           GeneratorUtil.describeIfExists(context.getInput(), "input"),
-          GeneratorUtil.describe(templateNode, "template"),
-          GeneratorUtil.describe(templateDeclaration, "template declaration"));
+          GeneratorUtil.createProblemDescription(templateNode, "template"),
+          GeneratorUtil.createProblemDescription(templateDeclaration, "template declaration"));
       return null;
     }
     return templateDeclarationInstance;

--- a/core/generator/source/jetbrains/mps/generator/impl/TemplateProcessor.java
+++ b/core/generator/source/jetbrains/mps/generator/impl/TemplateProcessor.java
@@ -149,7 +149,7 @@ public final class TemplateProcessor implements ITemplateProcessor {
           myGenerator.getLogger().warning(rtTemplateChildNode.getTemplateNodeReference(), status.getMessage("apply template"), status.describe(
               GeneratorUtil.describe(context.getInput(), "input"),
               GeneratorUtil.describe(outputNode, "output"),
-              GeneratorUtil.describe(rtTemplateNode.getTemplateNodeReference(), "template node")
+              GeneratorUtil.createProblemDescription(rtTemplateNode.getTemplateNodeReference(), "template node")
           ));
         }
         outputNode.addChild(role, outputChildNode);


### PR DESCRIPTION
This class is used to represent GeneratorUtil.  The method named 'describe' is to create a problem description. Thus, the method name 'createProblemDescription' is more intuitive than 'describe'.