### PR TITLE
Change method name 'dispose' to 'removeRepository'

### DIFF
--- a/core/kernel/source/jetbrains/mps/extapi/module/SRepositoryBase.java
+++ b/core/kernel/source/jetbrains/mps/extapi/module/SRepositoryBase.java
@@ -57,7 +57,7 @@ public abstract class SRepositoryBase implements SRepository {
     }
   }
 
-  public void dispose() {
+  public void removeRepository() {
     if (myRepositoryRegistry != null){
       myRepositoryRegistry.removeRepository(this);
     }

--- a/core/kernel/source/jetbrains/mps/smodel/MPSModuleRepository.java
+++ b/core/kernel/source/jetbrains/mps/smodel/MPSModuleRepository.java
@@ -118,12 +118,12 @@ public class MPSModuleRepository extends SRepositoryBase implements CoreComponen
   }
 
   @Override
-  public void dispose() {
+  public void removeRepository() {
     myModelRepository.dispose();
     myGlobalModelAccess.removeReadActionListener(myScopeCache);
     myGlobalModelAccess.removeCommandListener(myCommandListener);
     ourInstance = null;
-    super.dispose();
+    super.removeRepository();
   }
 
   // friend-only access, for ModuleRepositoryFacade.

--- a/core/project/source/jetbrains/mps/project/Project.java
+++ b/core/project/source/jetbrains/mps/project/Project.java
@@ -190,7 +190,7 @@ public abstract class Project implements MPSModuleOwner, IProject {
    * closes and disposes the project
    */
   public void dispose() {
-    myRepository.dispose();
+    myRepository.removeRepository();
     myDisposed = true;
   }
 


### PR DESCRIPTION
This class is used to represent SRepositoryBase.  The method named 'dispose' is to remove repository. Thus, the method name 'removeRepository' is more intuitive than 'dispose'.