### PR TITLE
Change method name 'found' to 'getPlugins'

### DIFF
--- a/core/tool/environment/source_gen/jetbrains/mps/tool/environment/LibraryContributorHelper.java
+++ b/core/tool/environment/source_gen/jetbrains/mps/tool/environment/LibraryContributorHelper.java
@@ -35,7 +35,7 @@ import jetbrains.mps.core.tool.environment.util.SetLibraryContributor;
   private Set<LibDescriptor> getPluginLibDescriptors(PlatformPlugins pp) {
     Set<LibDescriptor> paths = new LinkedHashSet<LibDescriptor>();
 
-    for (PlatformPlugins.Descriptor descriptor : pp.found()) {
+    for (PlatformPlugins.Descriptor descriptor : pp.getPlugins()) {
       final ClassLoader pluginCL = descriptor.classLoader();
       // XXX next code assumes that for each .jar under lib/ there are MPS modules bundled inside (!/modules). 
       //     Would like to find out if it's still relevant, as it looks like a bad idea to mix lib/ classpath with module locations 

--- a/core/tool/environment/source_gen/jetbrains/mps/tool/environment/PlatformPlugins.java
+++ b/core/tool/environment/source_gen/jetbrains/mps/tool/environment/PlatformPlugins.java
@@ -119,7 +119,7 @@ import java.net.URLClassLoader;
     }
   }
 
-  /*package*/ Collection<Descriptor> found() {
+  /*package*/ Collection<Descriptor> getPlugins() {
     //  provisional method, just to move forward. I indend to hide implementation structures from the outer world eventually. 
     return Collections.<Descriptor>unmodifiableCollection(myPlugins.values());
   }


### PR DESCRIPTION
This class is used to represent PlatformPlugins.  The method named 'found' is to get plugins. Thus, the method name 'getPlugins' is more intuitive than 'found'.