### PR TITLE
fixed missing type cache when computing substitute actions during typing

### DIFF
--- a/editor/editor-runtime/source/jetbrains/mps/nodeEditor/IntelligentInputUtil.java
+++ b/editor/editor-runtime/source/jetbrains/mps/nodeEditor/IntelligentInputUtil.java
@@ -86,7 +86,13 @@ public class IntelligentInputUtil {
     private void cacheSubstituteInfo() {
       // Todo this is the hack for the caching The actions are calculated in the read action and not in the command, so the RepositoryStateCacheUtils is used
       // Todo when redesigning SubstituteInfo and IntelligentInputUtil cache will be separated from getting the actions
-      myEditorContext.getRepository().getModelAccess().runReadAction(() -> mySubstituteInfo.getMatchingActions("", false));
+      TypeContextManager.getInstance().runTypeCheckingAction(
+          ((EditorComponent) myEditorContext.getEditorComponent()).getTypecheckingContextOwner(),
+          myEditorContext.getEditorComponent().getEditedNode(),
+          ctx -> {
+            myEditorContext.getRepository().getModelAccess().runReadAction(() -> mySubstituteInfo.getMatchingActions("", false));
+          }
+      );
     }
 
     private SubstituteInfo createSubstituteInfo(final SubstituteInfo substituteInfo) {


### PR DESCRIPTION
This PR fixes the issue with missing type cache when the list of available substitute actions is computed for a cell on typing.

When opening a CC-menu on a new cell, the list of available actions gets quickly computed and shown to the user, but when trying to type something in the same new cell, there is a lag of several seconds before the typed text appears in the cell. In case of CC menu the list of substitute actions is calculated in `NodeSubstituteChooserHandler.getMatchingActions()` inside of a type-checking computation that uses current editor component as type context owner (and hence its type cache). But when something is typed, then the list of substitute actions for the current cell is computed in `IntelligentInputUtil.IntelligentCellProcessor.cacheSubstituteInfo()` directly w/o being wrapped in any type-checking action. And hence there is no type cache when constraints code for available concepts is executed.