### PR TITLE
IntentionsManager: gracefully handle exceptions in isApplicable

### DIFF
--- a/editor/intentions-runtime/source/jetbrains/mps/intentions/IntentionsManager.java
+++ b/editor/intentions-runtime/source/jetbrains/mps/intentions/IntentionsManager.java
@@ -373,9 +373,21 @@ public class IntentionsManager implements PersistentStateComponent<IntentionsMan
         if (isAncestor && !intentionFactory.isAvailableInChildNodes()) {
           continue;
         }
-        if (!filter.accept(intentionFactory) || !intentionFactory.isApplicable(node, editorContext)) {
+
+        if (!filter.accept(intentionFactory)) {
           continue;
         }
+
+        boolean isApplicable = false;
+        try {
+          isApplicable = intentionFactory.isApplicable(node, editorContext);
+        } catch (Throwable t) {
+          LOG.error("Failed to evaluate isApplicable for " + intentionFactory.getClass().getName(), t);
+        }
+        if (!isApplicable) {
+          continue;
+        }
+
         if (!visitor.visit(intentionFactory)) {
           return false;
         }


### PR DESCRIPTION
If the isApplicable method of an intentions throws an exception the IntentionsManager
catches the exception, logs it and ignores the intention.

Right now the complete intentions menu becomes unusable if a single intentions throws
an exception.