### PR TITLE
MPS-33334 Fix doubled word in error message

### DIFF
--- a/languages/languageDesign/generator/languages/templateLanguage/languageModels/typesystem.mps
+++ b/languages/languageDesign/generator/languages/templateLanguage/languageModels/typesystem.mps
@@ -3880,7 +3880,7 @@
                         <ref role="1Pybhc" to="wyt6:~String" resolve="String" />
                         <ref role="37wK5l" to="wyt6:~String.format(java.lang.String,java.lang.Object...)" resolve="format" />
                         <node concept="Xl_RD" id="4fnTrxcpvat" role="37wK5m">
-                          <property role="Xl_RC" value="Template Fragments shall use same same containment link" />
+                          <property role="Xl_RC" value="Template Fragments shall use same containment link" />
                         </node>
                       </node>
                       <node concept="37vLTw" id="4fnTrxcpvar" role="1urrMF">
@@ -6265,7 +6265,7 @@
                         <ref role="1Pybhc" to="wyt6:~String" resolve="String" />
                         <ref role="37wK5l" to="wyt6:~String.format(java.lang.String,java.lang.Object...)" resolve="format" />
                         <node concept="Xl_RD" id="4fnTrxcptur" role="37wK5m">
-                          <property role="Xl_RC" value="Template Fragments shall use same same containment link" />
+                          <property role="Xl_RC" value="Template Fragments shall use same containment link" />
                         </node>
                       </node>
                       <node concept="37vLTw" id="4fnTrxcptup" role="1urrMF">

--- a/languages/languageDesign/generator/languages/templateLanguage/source_gen/jetbrains/mps/lang/generator/typesystem/aspectcps-descriptorclasses.mps
+++ b/languages/languageDesign/generator/languages/templateLanguage/source_gen/jetbrains/mps/lang/generator/typesystem/aspectcps-descriptorclasses.mps
@@ -7539,7 +7539,7 @@
                                     <ref role="37wK5l" to="wyt6:~String.format(java.lang.String,java.lang.Object...)" resolve="format" />
                                     <uo k="s:originTrace" v="n:4888628500252448666" />
                                     <node concept="Xl_RD" id="$$" role="37wK5m">
-                                      <property role="Xl_RC" value="Template Fragments shall use same same containment link" />
+                                      <property role="Xl_RC" value="Template Fragments shall use same containment link" />
                                       <uo k="s:originTrace" v="n:4888628500252448667" />
                                     </node>
                                   </node>
@@ -11732,7 +11732,7 @@
                                     <ref role="37wK5l" to="wyt6:~String.format(java.lang.String,java.lang.Object...)" resolve="format" />
                                     <uo k="s:originTrace" v="n:4888628500252455580" />
                                     <node concept="Xl_RD" id="Sz" role="37wK5m">
-                                      <property role="Xl_RC" value="Template Fragments shall use same same containment link" />
+                                      <property role="Xl_RC" value="Template Fragments shall use same containment link" />
                                       <uo k="s:originTrace" v="n:4888628500252455581" />
                                     </node>
                                   </node>

--- a/languages/languageDesign/generator/languages/templateLanguage/source_gen/jetbrains/mps/lang/generator/typesystem/check_InlineTemplateWithContext_RuleConsequence_NonTypesystemRule.java
+++ b/languages/languageDesign/generator/languages/templateLanguage/source_gen/jetbrains/mps/lang/generator/typesystem/check_InlineTemplateWithContext_RuleConsequence_NonTypesystemRule.java
@@ -43,7 +43,7 @@ public class check_InlineTemplateWithContext_RuleConsequence_NonTypesystemRule e
         if (!(Objects.equals(commonAggregationLink, fragmentParent.getContainmentLink()))) {
           {
             final MessageTarget errorTarget = new NodeMessageTarget();
-            IErrorReporter _reporter_2309309498 = typeCheckingContext.reportTypeError(tf, String.format("Template Fragments shall use same same containment link"), "r:00000000-0000-4000-0000-011c895902e4(jetbrains.mps.lang.generator.typesystem)", "4888628500252448664", null, errorTarget);
+            IErrorReporter _reporter_2309309498 = typeCheckingContext.reportTypeError(tf, String.format("Template Fragments shall use same containment link"), "r:00000000-0000-4000-0000-011c895902e4(jetbrains.mps.lang.generator.typesystem)", "4888628500252448664", null, errorTarget);
           }
         }
       }

--- a/languages/languageDesign/generator/languages/templateLanguage/source_gen/jetbrains/mps/lang/generator/typesystem/check_TemplateDeclaration_NonTypesystemRule.java
+++ b/languages/languageDesign/generator/languages/templateLanguage/source_gen/jetbrains/mps/lang/generator/typesystem/check_TemplateDeclaration_NonTypesystemRule.java
@@ -51,7 +51,7 @@ public class check_TemplateDeclaration_NonTypesystemRule extends AbstractNonType
         if (!(Objects.equals(commonAggregationLink, fragmentParent.getContainmentLink()))) {
           {
             final MessageTarget errorTarget = new NodeMessageTarget();
-            IErrorReporter _reporter_2309309498 = typeCheckingContext.reportTypeError(tf, String.format("Template Fragments shall use same same containment link"), "r:00000000-0000-4000-0000-011c895902e4(jetbrains.mps.lang.generator.typesystem)", "4888628500252455578", null, errorTarget);
+            IErrorReporter _reporter_2309309498 = typeCheckingContext.reportTypeError(tf, String.format("Template Fragments shall use same containment link"), "r:00000000-0000-4000-0000-011c895902e4(jetbrains.mps.lang.generator.typesystem)", "4888628500252455578", null, errorTarget);
           }
         }
       }


### PR DESCRIPTION
Doubled "same" occurs in this message:
`Template Fragments shall use same same containment link`

for example here:
<img width="1092" alt="Screenshot 2021-05-01 at 19 47 35" src="https://user-images.githubusercontent.com/5954346/116791144-abebe500-aab8-11eb-9d1a-08400332b5b3.png">

Issue: MPS-33334
Signed-off-by: Cornel Izbasa <badc0ded@gmail.com>