### PR TITLE
Add optional hint to messages logging statement

### DIFF
--- a/.mps/modules.xml
+++ b/.mps/modules.xml
@@ -522,6 +522,7 @@
       <modulePath path="$PROJECT_DIR$/samples/xmlPersistence/languages/jetbrains.mps.samples.xmlPersistence.build/jetbrains.mps.samples.xmlPersistence.build.msd" folder="samples.persistence" />
       <modulePath path="$PROJECT_DIR$/samples/xmlPersistence/languages/jetbrains.mps.samples.xmlPersistence.ideaPlugin/jetbrains.mps.samples.xmlPersistence.ideaPlugin.msd" folder="samples.persistence" />
       <modulePath path="$PROJECT_DIR$/samples/xmlPersistence/languages/jetbrains.mps.samples.xmlPersistence/jetbrains.mps.samples.xmlPersistence.msd" folder="samples.persistence" />
+      <modulePath path="$PROJECT_DIR$/solutions/test/test.msd" folder="" />
       <modulePath path="$PROJECT_DIR$/testbench/ideatestsolutions/ide.vcs.test/jetbrains.mps.ide.vcs.test.msd" folder="platform.vcs" />
       <modulePath path="$PROJECT_DIR$/testbench/jetbrains.mps.build.mps.testModules/jetbrains.mps.build.mps.testModules.msd" folder="platform.build" />
       <modulePath path="$PROJECT_DIR$/testbench/jetbrains.mps.testbench.make/jetbrains.mps.testbench.make.msd" folder="testbench" />

--- a/languages.test/languageDesign/lang.editor.editorTest.extension/jetbrains.mps.lang.editor.editorTest.extension.mpl
+++ b/languages.test/languageDesign/lang.editor.editorTest.extension/jetbrains.mps.lang.editor.editorTest.extension.mpl
@@ -48,6 +48,7 @@
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
         <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
         <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />

--- a/languages/baseLanguage/logging/generator/source_gen.caches/jetbrains/mps/baseLanguage/logging/generated
+++ b/languages/baseLanguage/logging/generator/source_gen.caches/jetbrains/mps/baseLanguage/logging/generated
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<product version="3" modelHash="crozv7i2zrbbgiv27brxg967e940d73">
+<product version="3" modelHash="1p9z7l5byz9y0w3tquq6u1dsjrkknkl">
   <files names="Generator.java" />
 </product>
 

--- a/languages/baseLanguage/logging/generator/source_gen.caches/jetbrains/mps/baseLanguage/logging/generator/baseLanguage/template/main/generated
+++ b/languages/baseLanguage/logging/generator/source_gen.caches/jetbrains/mps/baseLanguage/logging/generator/baseLanguage/template/main/generated
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<product version="3" modelHash="8rkbglgprjql9vqpkt8obp9cvr3q18s">
+<product version="3" modelHash="4rhshuym7q8hoapthdn8ek0wjm52m3a">
   <files names="QueriesGenerated.java" />
 </product>
 

--- a/languages/baseLanguage/logging/generator/source_gen/jetbrains/mps/baseLanguage/logging/generator/baseLanguage/template/main/QueriesGenerated.java
+++ b/languages/baseLanguage/logging/generator/source_gen/jetbrains/mps/baseLanguage/logging/generator/baseLanguage/template/main/QueriesGenerated.java
@@ -132,6 +132,9 @@ public class QueriesGenerated extends QueryProviderBase {
   public static boolean ifMacro_Condition_4_1(final IfMacroContext _context) {
     return SLinkOperations.getTarget(_context.getNode(), LINKS.project$OYlE) != null;
   }
+  public static boolean ifMacro_Condition_4_2(final IfMacroContext _context) {
+    return SLinkOperations.getTarget(_context.getNode(), LINKS.hint$bvDr) != null;
+  }
   public static SNode sourceNodeQuery_1_0(final SourceSubstituteMacroNodeContext _context) {
     return LoggingGenerationUtil.toPlus(SLinkOperations.getChildren(_context.getNode(), LINKS.textExpression$SldK));
   }
@@ -142,6 +145,9 @@ public class QueriesGenerated extends QueryProviderBase {
     return SLinkOperations.getTarget(_context.getNode(), LINKS.project$OYlE);
   }
   public static SNode sourceNodeQuery_4_2(final SourceSubstituteMacroNodeContext _context) {
+    return SLinkOperations.getTarget(_context.getNode(), LINKS.hint$bvDr);
+  }
+  public static SNode sourceNodeQuery_4_3(final SourceSubstituteMacroNodeContext _context) {
     return SLinkOperations.getTarget(_context.getNode(), LINKS.message$I3Bb);
   }
   public static SNode sourceNodeQuery_6_0(final SourceSubstituteMacroNodeContext _context) {
@@ -290,6 +296,7 @@ public class QueriesGenerated extends QueryProviderBase {
     snqMethods.put("1168402886104", new SNQ(i++));
     snqMethods.put("3679134236456128502", new SNQ(i++));
     snqMethods.put("3679134236456128522", new SNQ(i++));
+    snqMethods.put("2096919206294062927", new SNQ(i++));
     snqMethods.put("3679134236455966537", new SNQ(i++));
     snqMethods.put("4663968267002877822", new SNQ(i++));
     snqMethods.put("4663968267002877830", new SNQ(i++));
@@ -317,8 +324,10 @@ public class QueriesGenerated extends QueryProviderBase {
         case 3:
           return QueriesGenerated.sourceNodeQuery_4_2(ctx);
         case 4:
-          return QueriesGenerated.sourceNodeQuery_6_0(ctx);
+          return QueriesGenerated.sourceNodeQuery_4_3(ctx);
         case 5:
+          return QueriesGenerated.sourceNodeQuery_6_0(ctx);
+        case 6:
           return QueriesGenerated.sourceNodeQuery_6_1(ctx);
         default:
           throw new GenerationFailureException(String.format("Inconsistent QueriesGenerated: there's no method for query %s (key: #%d)", ctx.getTemplateReference(), methodKey));
@@ -358,6 +367,7 @@ public class QueriesGenerated extends QueryProviderBase {
     imcMethods.put("4663968267002902090", new IfMC(i++));
     imcMethods.put("3679134236456128490", new IfMC(i++));
     imcMethods.put("3679134236456128510", new IfMC(i++));
+    imcMethods.put("2096919206294062915", new IfMC(i++));
   }
   @NotNull
   @Override
@@ -379,6 +389,8 @@ public class QueriesGenerated extends QueryProviderBase {
           return QueriesGenerated.ifMacro_Condition_4_0(ctx);
         case 2:
           return QueriesGenerated.ifMacro_Condition_4_1(ctx);
+        case 3:
+          return QueriesGenerated.ifMacro_Condition_4_2(ctx);
         default:
           throw new GenerationFailureException(String.format("Inconsistent QueriesGenerated: there's no condition method for if macro %s (key: #%d)", ctx.getTemplateReference(), methodKey));
       }
@@ -466,6 +478,7 @@ public class QueriesGenerated extends QueryProviderBase {
   private static final class LINKS {
     /*package*/ static final SContainmentLink throwable$I3Qc = MetaAdapterFactory.getContainmentLink(0x760a0a8ceabb4521L, 0x8bfd65db761a9ba3L, 0x57e2cf14f6d5a71dL, 0x4f67298c4630c25fL, "throwable");
     /*package*/ static final SContainmentLink project$OYlE = MetaAdapterFactory.getContainmentLink(0x760a0a8ceabb4521L, 0x8bfd65db761a9ba3L, 0x57e2cf14f6d5a71dL, 0x4f67298c4630c318L, "project");
+    /*package*/ static final SContainmentLink hint$bvDr = MetaAdapterFactory.getContainmentLink(0x760a0a8ceabb4521L, 0x8bfd65db761a9ba3L, 0x57e2cf14f6d5a71dL, 0x1d19c0e87d9d67c2L, "hint");
     /*package*/ static final SContainmentLink textExpression$SldK = MetaAdapterFactory.getContainmentLink(0x760a0a8ceabb4521L, 0x8bfd65db761a9ba3L, 0x1100a2cc320L, 0x1100a2d9863L, "textExpression");
     /*package*/ static final SContainmentLink message$I3Bb = MetaAdapterFactory.getContainmentLink(0x760a0a8ceabb4521L, 0x8bfd65db761a9ba3L, 0x57e2cf14f6d5a71dL, 0x4f67298c4630c25eL, "message");
     /*package*/ static final SContainmentLink message$TfWL = MetaAdapterFactory.getContainmentLink(0x760a0a8ceabb4521L, 0x8bfd65db761a9ba3L, 0x1c3d779b2be2f0b9L, 0x1c3d779b2be2f1b9L, "message");

--- a/languages/baseLanguage/logging/generator/source_gen/jetbrains/mps/baseLanguage/logging/generator/baseLanguage/template/main/trace.info
+++ b/languages/baseLanguage/logging/generator/source_gen/jetbrains/mps/baseLanguage/logging/generator/baseLanguage/template/main/trace.info
@@ -10,18 +10,18 @@
   <concept fqn="c:f3061a53-9226-4cc5-a443-f952ceaf5816/1164991038168:jetbrains.mps.baseLanguage.structure.ThrowStatement" />
   <root>
     <file name="QueriesGenerated.java">
-      <unit at="461,0,465,0" name="jetbrains.mps.baseLanguage.logging.generator.baseLanguage.template.main.QueriesGenerated$PROPS" />
-      <unit at="454,0,460,0" name="jetbrains.mps.baseLanguage.logging.generator.baseLanguage.template.main.QueriesGenerated$CONCEPTS" />
-      <unit at="466,0,475,0" name="jetbrains.mps.baseLanguage.logging.generator.baseLanguage.template.main.QueriesGenerated$LINKS" />
-      <unit at="272,0,287,0" name="jetbrains.mps.baseLanguage.logging.generator.baseLanguage.template.main.QueriesGenerated$MCC" />
-      <unit at="438,0,453,0" name="jetbrains.mps.baseLanguage.logging.generator.baseLanguage.template.main.QueriesGenerated$VVQ" />
-      <unit at="339,0,355,0" name="jetbrains.mps.baseLanguage.logging.generator.baseLanguage.template.main.QueriesGenerated$PVQ" />
-      <unit at="186,0,203,0" name="jetbrains.mps.baseLanguage.logging.generator.baseLanguage.template.main.QueriesGenerated$RRC" />
-      <unit at="368,0,387,0" name="jetbrains.mps.baseLanguage.logging.generator.baseLanguage.template.main.QueriesGenerated$IfMC" />
-      <unit at="303,0,328,0" name="jetbrains.mps.baseLanguage.logging.generator.baseLanguage.template.main.QueriesGenerated$SNQ" />
-      <unit at="402,0,428,0" name="jetbrains.mps.baseLanguage.logging.generator.baseLanguage.template.main.QueriesGenerated$RTQ" />
-      <unit at="226,0,261,0" name="jetbrains.mps.baseLanguage.logging.generator.baseLanguage.template.main.QueriesGenerated$WRQ" />
-      <unit at="49,0,476,0" name="jetbrains.mps.baseLanguage.logging.generator.baseLanguage.template.main.QueriesGenerated" />
+      <unit at="473,0,477,0" name="jetbrains.mps.baseLanguage.logging.generator.baseLanguage.template.main.QueriesGenerated$PROPS" />
+      <unit at="466,0,472,0" name="jetbrains.mps.baseLanguage.logging.generator.baseLanguage.template.main.QueriesGenerated$CONCEPTS" />
+      <unit at="478,0,488,0" name="jetbrains.mps.baseLanguage.logging.generator.baseLanguage.template.main.QueriesGenerated$LINKS" />
+      <unit at="278,0,293,0" name="jetbrains.mps.baseLanguage.logging.generator.baseLanguage.template.main.QueriesGenerated$MCC" />
+      <unit at="450,0,465,0" name="jetbrains.mps.baseLanguage.logging.generator.baseLanguage.template.main.QueriesGenerated$VVQ" />
+      <unit at="348,0,364,0" name="jetbrains.mps.baseLanguage.logging.generator.baseLanguage.template.main.QueriesGenerated$PVQ" />
+      <unit at="192,0,209,0" name="jetbrains.mps.baseLanguage.logging.generator.baseLanguage.template.main.QueriesGenerated$RRC" />
+      <unit at="378,0,399,0" name="jetbrains.mps.baseLanguage.logging.generator.baseLanguage.template.main.QueriesGenerated$IfMC" />
+      <unit at="414,0,440,0" name="jetbrains.mps.baseLanguage.logging.generator.baseLanguage.template.main.QueriesGenerated$RTQ" />
+      <unit at="310,0,337,0" name="jetbrains.mps.baseLanguage.logging.generator.baseLanguage.template.main.QueriesGenerated$SNQ" />
+      <unit at="232,0,267,0" name="jetbrains.mps.baseLanguage.logging.generator.baseLanguage.template.main.QueriesGenerated$WRQ" />
+      <unit at="49,0,489,0" name="jetbrains.mps.baseLanguage.logging.generator.baseLanguage.template.main.QueriesGenerated" />
     </file>
   </root>
   <root nodeRef="r:00000000-0000-4000-0000-011c89590580(jetbrains.mps.baseLanguage.logging.generator.baseLanguage.template.main@generator)/1167240570149">
@@ -29,44 +29,44 @@
       <node id="1210168259739" at="54,83,55,226" concept="4" />
       <node id="5721587534047451055" at="57,83,58,113" concept="4" />
       <node id="2034914114981278220" at="60,83,61,113" concept="4" />
-      <node id="3679134236455653278" at="153,94,154,83" concept="5" />
-      <node id="3679134236455661035" at="154,83,155,82" concept="5" />
-      <node id="1187224257845" at="155,82,156,84" concept="3" />
-      <node id="3679134236455652847" at="157,29,158,80" concept="5" />
-      <node id="3561282099138216050" at="158,80,159,180" concept="3" />
-      <node id="3561282099138216086" at="159,180,160,100" concept="3" />
-      <node id="3561282099138216158" at="160,100,161,116" concept="4" />
-      <node id="1187224306039" at="162,5,163,22" concept="4" />
-      <node id="6058585399864262730" at="165,84,166,166" concept="4" />
-      <node id="6450631649356160128" at="168,77,169,188" concept="4" />
-      <node id="5721587534047451051" at="176,14,177,56" concept="1" />
-      <node id="2034914114981278216" at="177,56,178,56" concept="1" />
-      <node id="5721587534047451051" at="194,15,195,58" concept="4" />
-      <node id="2034914114981278216" at="196,15,197,58" concept="4" />
-      <node id="1169464520732" at="205,14,206,51" concept="1" />
-      <node id="1169464520732" at="234,15,235,58" concept="4" />
-      <node id="1169464520732" at="243,15,244,68" concept="4" />
-      <node id="1169464520732" at="254,15,255,63" concept="4" />
-      <node id="1167240570149" at="263,14,264,50" concept="1" />
-      <node id="1167240570149" at="280,15,281,54" concept="4" />
+      <node id="3679134236455653278" at="159,94,160,83" concept="5" />
+      <node id="3679134236455661035" at="160,83,161,82" concept="5" />
+      <node id="1187224257845" at="161,82,162,84" concept="3" />
+      <node id="3679134236455652847" at="163,29,164,80" concept="5" />
+      <node id="3561282099138216050" at="164,80,165,180" concept="3" />
+      <node id="3561282099138216086" at="165,180,166,100" concept="3" />
+      <node id="3561282099138216158" at="166,100,167,116" concept="4" />
+      <node id="1187224306039" at="168,5,169,22" concept="4" />
+      <node id="6058585399864262730" at="171,84,172,166" concept="4" />
+      <node id="6450631649356160128" at="174,77,175,188" concept="4" />
+      <node id="5721587534047451051" at="182,14,183,56" concept="1" />
+      <node id="2034914114981278216" at="183,56,184,56" concept="1" />
+      <node id="5721587534047451051" at="200,15,201,58" concept="4" />
+      <node id="2034914114981278216" at="202,15,203,58" concept="4" />
+      <node id="1169464520732" at="211,14,212,51" concept="1" />
+      <node id="1169464520732" at="240,15,241,58" concept="4" />
+      <node id="1169464520732" at="249,15,250,68" concept="4" />
+      <node id="1169464520732" at="260,15,261,63" concept="4" />
+      <node id="1167240570149" at="269,14,270,50" concept="1" />
+      <node id="1167240570149" at="286,15,287,54" concept="4" />
       <node id="1169464530672" at="54,0,57,0" concept="6" trace="rule_Condition_0_0#(Ljetbrains/mps/generator/template/BaseMappingRuleContext;)Z" />
       <node id="5721587534047451053" at="57,0,60,0" concept="6" trace="rule_Condition_0_1#(Ljetbrains/mps/generator/template/BaseMappingRuleContext;)Z" />
       <node id="2034914114981278218" at="60,0,63,0" concept="6" trace="rule_Condition_0_2#(Ljetbrains/mps/generator/template/BaseMappingRuleContext;)Z" />
-      <node id="6058585399864258723" at="165,0,168,0" concept="6" trace="weaving_AnchorQuery_0_0#(Ljetbrains/mps/generator/template/WeavingAnchorContext;)Lorg/jetbrains/mps/openapi/model/SNode;" />
-      <node id="6450631649356134114" at="168,0,171,0" concept="6" trace="mc_Condition_0#(Ljetbrains/mps/generator/template/TemplateQueryContext;)Z" />
-      <node id="1187224263927" at="156,84,162,5" concept="2" />
-      <node id="1187224198430" at="153,0,165,0" concept="6" trace="weavingRule_ContextQuery_0_0#(Ljetbrains/mps/generator/template/WeavingMappingRuleContext;)Lorg/jetbrains/mps/openapi/model/SNode;" />
+      <node id="6058585399864258723" at="171,0,174,0" concept="6" trace="weaving_AnchorQuery_0_0#(Ljetbrains/mps/generator/template/WeavingAnchorContext;)Lorg/jetbrains/mps/openapi/model/SNode;" />
+      <node id="6450631649356134114" at="174,0,177,0" concept="6" trace="mc_Condition_0#(Ljetbrains/mps/generator/template/TemplateQueryContext;)Z" />
+      <node id="1187224263927" at="162,84,168,5" concept="2" />
+      <node id="1187224198430" at="159,0,171,0" concept="6" trace="weavingRule_ContextQuery_0_0#(Ljetbrains/mps/generator/template/WeavingMappingRuleContext;)Lorg/jetbrains/mps/openapi/model/SNode;" />
       <scope id="1169464530673" at="54,83,55,226" />
       <scope id="5721587534047451054" at="57,83,58,113" />
       <scope id="2034914114981278219" at="60,83,61,113" />
-      <scope id="6058585399864258724" at="165,84,166,166" />
-      <scope id="6450631649356146489" at="168,77,169,188" />
-      <scope id="5721587534047451051" at="194,15,195,58" />
-      <scope id="2034914114981278216" at="196,15,197,58" />
-      <scope id="1169464520732" at="234,15,235,58" />
-      <scope id="1169464520732" at="243,15,244,68" />
-      <scope id="1169464520732" at="254,15,255,63" />
-      <scope id="1167240570149" at="280,15,281,54" />
+      <scope id="6058585399864258724" at="171,84,172,166" />
+      <scope id="6450631649356146489" at="174,77,175,188" />
+      <scope id="5721587534047451051" at="200,15,201,58" />
+      <scope id="2034914114981278216" at="202,15,203,58" />
+      <scope id="1169464520732" at="240,15,241,58" />
+      <scope id="1169464520732" at="249,15,250,68" />
+      <scope id="1169464520732" at="260,15,261,63" />
+      <scope id="1167240570149" at="286,15,287,54" />
       <scope id="1169464530672" at="54,0,57,0">
         <var name="_context" id="1169464530672" />
       </scope>
@@ -76,20 +76,20 @@
       <scope id="2034914114981278218" at="60,0,63,0">
         <var name="_context" id="2034914114981278218" />
       </scope>
-      <scope id="6058585399864258723" at="165,0,168,0">
+      <scope id="6058585399864258723" at="171,0,174,0">
         <var name="_context" id="6058585399864258723" />
       </scope>
-      <scope id="6450631649356134114" at="168,0,171,0">
+      <scope id="6450631649356134114" at="174,0,177,0">
         <var name="_context" id="6450631649356134114" />
       </scope>
-      <scope id="1187224263928" at="157,29,161,116">
+      <scope id="1187224263928" at="163,29,167,116">
         <var name="logStatement" id="3561282099138216051" />
         <var name="usage" id="3561282099138216087" />
       </scope>
-      <scope id="1187224198431" at="153,94,163,22">
+      <scope id="1187224198431" at="159,94,169,22">
         <var name="outputNode" id="1187224257846" />
       </scope>
-      <scope id="1187224198430" at="153,0,165,0">
+      <scope id="1187224198430" at="159,0,171,0">
         <var name="_context" id="1187224198430" />
       </scope>
     </file>
@@ -106,30 +106,38 @@
       <node id="3679134236456069800" at="82,12,83,134" concept="4" />
       <node id="3679134236456128493" at="129,78,130,87" concept="4" />
       <node id="3679134236456128513" at="132,78,133,85" concept="4" />
-      <node id="3679134236456128504" at="138,92,139,79" concept="4" />
-      <node id="3679134236456128524" at="141,92,142,77" concept="4" />
-      <node id="3679134236455966539" at="144,92,145,77" concept="4" />
-      <node id="3679134236456128502" at="290,50,291,56" concept="1" />
-      <node id="3679134236456128522" at="291,56,292,56" concept="1" />
-      <node id="3679134236455966537" at="292,56,293,56" concept="1" />
-      <node id="3679134236456128502" at="313,15,314,59" concept="4" />
-      <node id="3679134236456128522" at="315,15,316,59" concept="4" />
-      <node id="3679134236455966537" at="317,15,318,59" concept="4" />
-      <node id="3679134236456128490" at="358,57,359,57" concept="1" />
-      <node id="3679134236456128510" at="359,57,360,57" concept="1" />
-      <node id="3679134236456128490" at="378,15,379,61" concept="4" />
-      <node id="3679134236456128510" at="380,15,381,61" concept="4" />
-      <node id="3679134236456128479" at="388,3,389,69" concept="1" />
-      <node id="3679134236455977443" at="389,69,390,62" concept="1" />
-      <node id="3679134236456128479" at="411,15,412,70" concept="4" />
-      <node id="3679134236455977443" at="413,15,414,70" concept="4" />
+      <node id="2096919206294062918" at="135,78,136,82" concept="4" />
+      <node id="3679134236456128504" at="141,92,142,79" concept="4" />
+      <node id="3679134236456128524" at="144,92,145,77" concept="4" />
+      <node id="2096919206294062929" at="147,92,148,74" concept="4" />
+      <node id="3679134236455966539" at="150,92,151,77" concept="4" />
+      <node id="3679134236456128502" at="296,50,297,56" concept="1" />
+      <node id="3679134236456128522" at="297,56,298,56" concept="1" />
+      <node id="2096919206294062927" at="298,56,299,56" concept="1" />
+      <node id="3679134236455966537" at="299,56,300,56" concept="1" />
+      <node id="3679134236456128502" at="320,15,321,59" concept="4" />
+      <node id="3679134236456128522" at="322,15,323,59" concept="4" />
+      <node id="2096919206294062927" at="324,15,325,59" concept="4" />
+      <node id="3679134236455966537" at="326,15,327,59" concept="4" />
+      <node id="3679134236456128490" at="367,57,368,57" concept="1" />
+      <node id="3679134236456128510" at="368,57,369,57" concept="1" />
+      <node id="2096919206294062915" at="369,57,370,57" concept="1" />
+      <node id="3679134236456128490" at="388,15,389,61" concept="4" />
+      <node id="3679134236456128510" at="390,15,391,61" concept="4" />
+      <node id="2096919206294062915" at="392,15,393,61" concept="4" />
+      <node id="3679134236456128479" at="400,3,401,69" concept="1" />
+      <node id="3679134236455977443" at="401,69,402,62" concept="1" />
+      <node id="3679134236456128479" at="423,15,424,70" concept="4" />
+      <node id="3679134236455977443" at="425,15,426,70" concept="4" />
       <node id="3679134236455966531" at="82,10,84,5" concept="0" />
       <node id="3679134236456128480" at="66,0,69,0" concept="6" trace="referenceMacro_GetReferent_4_0#(Ljetbrains/mps/generator/template/ReferenceMacroContext;)Ljava/lang/Object;" />
       <node id="3679134236456128491" at="129,0,132,0" concept="6" trace="ifMacro_Condition_4_0#(Ljetbrains/mps/generator/template/IfMacroContext;)Z" />
       <node id="3679134236456128511" at="132,0,135,0" concept="6" trace="ifMacro_Condition_4_1#(Ljetbrains/mps/generator/template/IfMacroContext;)Z" />
-      <node id="3679134236456128502" at="138,0,141,0" concept="6" trace="sourceNodeQuery_4_0#(Ljetbrains/mps/generator/template/SourceSubstituteMacroNodeContext;)Lorg/jetbrains/mps/openapi/model/SNode;" />
-      <node id="3679134236456128522" at="141,0,144,0" concept="6" trace="sourceNodeQuery_4_1#(Ljetbrains/mps/generator/template/SourceSubstituteMacroNodeContext;)Lorg/jetbrains/mps/openapi/model/SNode;" />
-      <node id="3679134236455966537" at="144,0,147,0" concept="6" trace="sourceNodeQuery_4_2#(Ljetbrains/mps/generator/template/SourceSubstituteMacroNodeContext;)Lorg/jetbrains/mps/openapi/model/SNode;" />
+      <node id="2096919206294062916" at="135,0,138,0" concept="6" trace="ifMacro_Condition_4_2#(Ljetbrains/mps/generator/template/IfMacroContext;)Z" />
+      <node id="3679134236456128502" at="141,0,144,0" concept="6" trace="sourceNodeQuery_4_0#(Ljetbrains/mps/generator/template/SourceSubstituteMacroNodeContext;)Lorg/jetbrains/mps/openapi/model/SNode;" />
+      <node id="3679134236456128522" at="144,0,147,0" concept="6" trace="sourceNodeQuery_4_1#(Ljetbrains/mps/generator/template/SourceSubstituteMacroNodeContext;)Lorg/jetbrains/mps/openapi/model/SNode;" />
+      <node id="2096919206294062927" at="147,0,150,0" concept="6" trace="sourceNodeQuery_4_2#(Ljetbrains/mps/generator/template/SourceSubstituteMacroNodeContext;)Lorg/jetbrains/mps/openapi/model/SNode;" />
+      <node id="3679134236455966537" at="150,0,153,0" concept="6" trace="sourceNodeQuery_4_3#(Ljetbrains/mps/generator/template/SourceSubstituteMacroNodeContext;)Lorg/jetbrains/mps/openapi/model/SNode;" />
       <node id="3679134236455966471" at="69,93,84,5" concept="2" />
       <node id="3679134236455977444" at="69,0,86,0" concept="6" trace="referenceMacro_GetReferent_4_1#(Ljetbrains/mps/generator/template/ReferenceMacroContext;)Ljava/lang/Object;" />
       <scope id="3679134236456128481" at="66,93,67,102" />
@@ -142,16 +150,20 @@
       <scope id="3679134236455966532" at="82,12,83,134" />
       <scope id="3679134236456128492" at="129,78,130,87" />
       <scope id="3679134236456128512" at="132,78,133,85" />
-      <scope id="3679134236456128503" at="138,92,139,79" />
-      <scope id="3679134236456128523" at="141,92,142,77" />
-      <scope id="3679134236455966538" at="144,92,145,77" />
-      <scope id="3679134236456128502" at="313,15,314,59" />
-      <scope id="3679134236456128522" at="315,15,316,59" />
-      <scope id="3679134236455966537" at="317,15,318,59" />
-      <scope id="3679134236456128490" at="378,15,379,61" />
-      <scope id="3679134236456128510" at="380,15,381,61" />
-      <scope id="3679134236456128479" at="411,15,412,70" />
-      <scope id="3679134236455977443" at="413,15,414,70" />
+      <scope id="2096919206294062917" at="135,78,136,82" />
+      <scope id="3679134236456128503" at="141,92,142,79" />
+      <scope id="3679134236456128523" at="144,92,145,77" />
+      <scope id="2096919206294062928" at="147,92,148,74" />
+      <scope id="3679134236455966538" at="150,92,151,77" />
+      <scope id="3679134236456128502" at="320,15,321,59" />
+      <scope id="3679134236456128522" at="322,15,323,59" />
+      <scope id="2096919206294062927" at="324,15,325,59" />
+      <scope id="3679134236455966537" at="326,15,327,59" />
+      <scope id="3679134236456128490" at="388,15,389,61" />
+      <scope id="3679134236456128510" at="390,15,391,61" />
+      <scope id="2096919206294062915" at="392,15,393,61" />
+      <scope id="3679134236456128479" at="423,15,424,70" />
+      <scope id="3679134236455977443" at="425,15,426,70" />
       <scope id="3679134236456128480" at="66,0,69,0">
         <var name="_context" id="3679134236456128480" />
       </scope>
@@ -161,13 +173,19 @@
       <scope id="3679134236456128511" at="132,0,135,0">
         <var name="_context" id="3679134236456128511" />
       </scope>
-      <scope id="3679134236456128502" at="138,0,141,0">
+      <scope id="2096919206294062916" at="135,0,138,0">
+        <var name="_context" id="2096919206294062916" />
+      </scope>
+      <scope id="3679134236456128502" at="141,0,144,0">
         <var name="_context" id="3679134236456128502" />
       </scope>
-      <scope id="3679134236456128522" at="141,0,144,0">
+      <scope id="3679134236456128522" at="144,0,147,0">
         <var name="_context" id="3679134236456128522" />
       </scope>
-      <scope id="3679134236455966537" at="144,0,147,0">
+      <scope id="2096919206294062927" at="147,0,150,0">
+        <var name="_context" id="2096919206294062927" />
+      </scope>
+      <scope id="3679134236455966537" at="150,0,153,0">
         <var name="_context" id="3679134236455966537" />
       </scope>
       <scope id="3679134236455977445" at="69,93,84,5" />
@@ -178,13 +196,13 @@
   </root>
   <root nodeRef="r:00000000-0000-4000-0000-011c89590580(jetbrains.mps.baseLanguage.logging.generator.baseLanguage.template.main@generator)/1168402205215">
     <file name="QueriesGenerated.java">
-      <node id="1210176882360" at="135,92,136,116" concept="4" />
-      <node id="1168402886104" at="289,14,290,50" concept="1" />
-      <node id="1168402886104" at="311,15,312,59" concept="4" />
-      <node id="1168402886104" at="135,0,138,0" concept="6" trace="sourceNodeQuery_1_0#(Ljetbrains/mps/generator/template/SourceSubstituteMacroNodeContext;)Lorg/jetbrains/mps/openapi/model/SNode;" />
-      <scope id="1168402886105" at="135,92,136,116" />
-      <scope id="1168402886104" at="311,15,312,59" />
-      <scope id="1168402886104" at="135,0,138,0">
+      <node id="1210176882360" at="138,92,139,116" concept="4" />
+      <node id="1168402886104" at="295,14,296,50" concept="1" />
+      <node id="1168402886104" at="318,15,319,59" concept="4" />
+      <node id="1168402886104" at="138,0,141,0" concept="6" trace="sourceNodeQuery_1_0#(Ljetbrains/mps/generator/template/SourceSubstituteMacroNodeContext;)Lorg/jetbrains/mps/openapi/model/SNode;" />
+      <scope id="1168402886105" at="138,92,139,116" />
+      <scope id="1168402886104" at="318,15,319,59" />
+      <scope id="1168402886104" at="138,0,141,0">
         <var name="_context" id="1168402886104" />
       </scope>
     </file>
@@ -192,11 +210,11 @@
   <root nodeRef="r:00000000-0000-4000-0000-011c89590580(jetbrains.mps.baseLanguage.logging.generator.baseLanguage.template.main@generator)/1169464243643">
     <file name="QueriesGenerated.java">
       <node id="4075687536653401294" at="63,88,64,106" concept="4" />
-      <node id="6675136286173559992" at="330,14,331,177" concept="1" />
-      <node id="6675136286173559992" at="348,15,349,66" concept="4" />
+      <node id="6675136286173559992" at="339,14,340,177" concept="1" />
+      <node id="6675136286173559992" at="357,15,358,66" concept="4" />
       <node id="6675136286173559993" at="63,0,66,0" concept="6" trace="propertyMacro_GetValue_2_0#(Ljetbrains/mps/generator/template/PropertyMacroContext;)Ljava/lang/Object;" />
       <scope id="6675136286173559994" at="63,88,64,106" />
-      <scope id="6675136286173559992" at="348,15,349,66" />
+      <scope id="6675136286173559992" at="357,15,358,66" />
       <scope id="6675136286173559993" at="63,0,66,0">
         <var name="_context" id="6675136286173559993" />
       </scope>
@@ -206,18 +224,18 @@
     <file name="QueriesGenerated.java">
       <node id="4663968267003040771" at="125,78,126,92" concept="5" />
       <node id="4663968267003025734" at="126,92,127,125" concept="4" />
-      <node id="4663968267002911537" at="171,78,172,127" concept="4" />
-      <node id="4663968267002902090" at="357,14,358,57" concept="1" />
-      <node id="4663968267002902090" at="376,15,377,61" concept="4" />
-      <node id="4663968267002902678" at="429,3,430,54" concept="1" />
-      <node id="4663968267002902678" at="446,15,447,58" concept="4" />
-      <node id="4663968267002902679" at="171,0,174,0" concept="6" trace="varMacro_Value_3_0#(Ljetbrains/mps/generator/template/TemplateVarContext;)Ljava/lang/Object;" />
+      <node id="4663968267002911537" at="177,78,178,127" concept="4" />
+      <node id="4663968267002902090" at="366,14,367,57" concept="1" />
+      <node id="4663968267002902090" at="386,15,387,61" concept="4" />
+      <node id="4663968267002902678" at="441,3,442,54" concept="1" />
+      <node id="4663968267002902678" at="458,15,459,58" concept="4" />
+      <node id="4663968267002902679" at="177,0,180,0" concept="6" trace="varMacro_Value_3_0#(Ljetbrains/mps/generator/template/TemplateVarContext;)Ljava/lang/Object;" />
       <node id="4663968267002902091" at="125,0,129,0" concept="6" trace="ifMacro_Condition_3_0#(Ljetbrains/mps/generator/template/IfMacroContext;)Z" />
-      <scope id="4663968267002902680" at="171,78,172,127" />
-      <scope id="4663968267002902090" at="376,15,377,61" />
-      <scope id="4663968267002902678" at="446,15,447,58" />
+      <scope id="4663968267002902680" at="177,78,178,127" />
+      <scope id="4663968267002902090" at="386,15,387,61" />
+      <scope id="4663968267002902678" at="458,15,459,58" />
       <scope id="4663968267002902092" at="125,78,127,125" />
-      <scope id="4663968267002902679" at="171,0,174,0">
+      <scope id="4663968267002902679" at="177,0,180,0">
         <var name="_context" id="4663968267002902679" />
       </scope>
       <scope id="4663968267002902091" at="125,0,129,0">
@@ -236,10 +254,10 @@
       <node id="4663968266992033810" at="99,128,100,134" concept="4" />
       <node id="4663968266992036828" at="101,128,102,134" concept="4" />
       <node id="4663968266992228883" at="103,5,104,148" concept="7" />
-      <node id="4663968266991950549" at="390,62,391,61" concept="1" />
-      <node id="4663968266991973473" at="391,61,392,69" concept="1" />
-      <node id="4663968266991950549" at="415,15,416,70" concept="4" />
-      <node id="4663968266991973473" at="417,15,418,70" concept="4" />
+      <node id="4663968266991950549" at="402,62,403,61" concept="1" />
+      <node id="4663968266991973473" at="403,61,404,69" concept="1" />
+      <node id="4663968266991950549" at="427,15,428,70" concept="4" />
+      <node id="4663968266991973473" at="429,15,430,70" concept="4" />
       <node id="4663968266991950550" at="86,0,89,0" concept="6" trace="referenceMacro_GetReferent_5_0#(Ljetbrains/mps/generator/template/ReferenceMacroContext;)Ljava/lang/Object;" />
       <node id="4663968266991981534" at="89,93,103,5" concept="2" />
       <node id="4663968266991973474" at="89,0,106,0" concept="6" trace="referenceMacro_GetReferent_5_1#(Ljetbrains/mps/generator/template/ReferenceMacroContext;)Ljava/lang/Object;" />
@@ -249,8 +267,8 @@
       <scope id="4663968266991981592" at="97,128,98,133" />
       <scope id="4663968266991981609" at="99,128,100,134" />
       <scope id="4663968266991981626" at="101,128,102,134" />
-      <scope id="4663968266991950549" at="415,15,416,70" />
-      <scope id="4663968266991973473" at="417,15,418,70" />
+      <scope id="4663968266991950549" at="427,15,428,70" />
+      <scope id="4663968266991973473" at="429,15,430,70" />
       <scope id="4663968266991981535" at="90,121,92,134" />
       <scope id="4663968266991950550" at="86,0,89,0">
         <var name="_context" id="4663968266991950550" />
@@ -271,19 +289,19 @@
       <node id="4663968267002877896" at="118,128,119,163" concept="4" />
       <node id="4663968267002877908" at="120,128,121,163" concept="4" />
       <node id="4663968267002877912" at="122,5,123,148" concept="7" />
-      <node id="4663968267002877824" at="147,92,148,77" concept="4" />
-      <node id="4663968267002877832" at="150,92,151,79" concept="4" />
-      <node id="4663968267002877822" at="293,56,294,56" concept="1" />
-      <node id="4663968267002877830" at="294,56,295,56" concept="1" />
-      <node id="4663968267002877822" at="319,15,320,59" concept="4" />
-      <node id="4663968267002877830" at="321,15,322,59" concept="4" />
-      <node id="4663968267002877805" at="392,69,393,61" concept="1" />
-      <node id="4663968267002877837" at="393,61,394,63" concept="1" />
-      <node id="4663968267002877805" at="419,15,420,70" concept="4" />
-      <node id="4663968267002877837" at="421,15,422,70" concept="4" />
+      <node id="4663968267002877824" at="153,92,154,77" concept="4" />
+      <node id="4663968267002877832" at="156,92,157,79" concept="4" />
+      <node id="4663968267002877822" at="300,56,301,56" concept="1" />
+      <node id="4663968267002877830" at="301,56,302,56" concept="1" />
+      <node id="4663968267002877822" at="328,15,329,59" concept="4" />
+      <node id="4663968267002877830" at="330,15,331,59" concept="4" />
+      <node id="4663968267002877805" at="404,69,405,61" concept="1" />
+      <node id="4663968267002877837" at="405,61,406,63" concept="1" />
+      <node id="4663968267002877805" at="431,15,432,70" concept="4" />
+      <node id="4663968267002877837" at="433,15,434,70" concept="4" />
       <node id="4663968267002877806" at="106,0,109,0" concept="6" trace="referenceMacro_GetReferent_6_0#(Ljetbrains/mps/generator/template/ReferenceMacroContext;)Ljava/lang/Object;" />
-      <node id="4663968267002877822" at="147,0,150,0" concept="6" trace="sourceNodeQuery_6_0#(Ljetbrains/mps/generator/template/SourceSubstituteMacroNodeContext;)Lorg/jetbrains/mps/openapi/model/SNode;" />
-      <node id="4663968267002877830" at="150,0,153,0" concept="6" trace="sourceNodeQuery_6_1#(Ljetbrains/mps/generator/template/SourceSubstituteMacroNodeContext;)Lorg/jetbrains/mps/openapi/model/SNode;" />
+      <node id="4663968267002877822" at="153,0,156,0" concept="6" trace="sourceNodeQuery_6_0#(Ljetbrains/mps/generator/template/SourceSubstituteMacroNodeContext;)Lorg/jetbrains/mps/openapi/model/SNode;" />
+      <node id="4663968267002877830" at="156,0,159,0" concept="6" trace="sourceNodeQuery_6_1#(Ljetbrains/mps/generator/template/SourceSubstituteMacroNodeContext;)Lorg/jetbrains/mps/openapi/model/SNode;" />
       <node id="4663968267002877840" at="109,93,122,5" concept="2" />
       <node id="4663968267002877838" at="109,0,125,0" concept="6" trace="referenceMacro_GetReferent_6_1#(Ljetbrains/mps/generator/template/ReferenceMacroContext;)Ljava/lang/Object;" />
       <scope id="4663968267002877807" at="106,93,107,130" />
@@ -293,19 +311,19 @@
       <scope id="4663968267002877883" at="116,128,117,162" />
       <scope id="4663968267002877895" at="118,128,119,163" />
       <scope id="4663968267002877907" at="120,128,121,163" />
-      <scope id="4663968267002877823" at="147,92,148,77" />
-      <scope id="4663968267002877831" at="150,92,151,79" />
-      <scope id="4663968267002877822" at="319,15,320,59" />
-      <scope id="4663968267002877830" at="321,15,322,59" />
-      <scope id="4663968267002877805" at="419,15,420,70" />
-      <scope id="4663968267002877837" at="421,15,422,70" />
+      <scope id="4663968267002877823" at="153,92,154,77" />
+      <scope id="4663968267002877831" at="156,92,157,79" />
+      <scope id="4663968267002877822" at="328,15,329,59" />
+      <scope id="4663968267002877830" at="330,15,331,59" />
+      <scope id="4663968267002877805" at="431,15,432,70" />
+      <scope id="4663968267002877837" at="433,15,434,70" />
       <scope id="4663968267002877806" at="106,0,109,0">
         <var name="_context" id="4663968267002877806" />
       </scope>
-      <scope id="4663968267002877822" at="147,0,150,0">
+      <scope id="4663968267002877822" at="153,0,156,0">
         <var name="_context" id="4663968267002877822" />
       </scope>
-      <scope id="4663968267002877830" at="150,0,153,0">
+      <scope id="4663968267002877830" at="156,0,159,0">
         <var name="_context" id="4663968267002877830" />
       </scope>
       <scope id="4663968267002877839" at="109,93,123,148" />

--- a/languages/baseLanguage/logging/generators/baseLanguage/templates/main@generator.mps
+++ b/languages/baseLanguage/logging/generators/baseLanguage/templates/main@generator.mps
@@ -1043,7 +1043,7 @@
                             <node concept="2OqwBi" id="1OpKexXQwt9" role="3uHU7B">
                               <node concept="30H73N" id="1OpKexXQwta" role="2Oq$k0" />
                               <node concept="3TrEf2" id="1OpKexXQwtb" role="2OqNvi">
-                                <ref role="3Tt5mk" to="tpib:1OpKexXBmv2" resolve="hintObject" />
+                                <ref role="3Tt5mk" to="tpib:1OpKexXBmv2" resolve="hint" />
                               </node>
                             </node>
                           </node>

--- a/languages/baseLanguage/logging/generators/baseLanguage/templates/main@generator.mps
+++ b/languages/baseLanguage/logging/generators/baseLanguage/templates/main@generator.mps
@@ -932,7 +932,7 @@
           <node concept="3clFbF" id="5vyNLjQPrRB" role="3cqZAp">
             <node concept="2OqwBi" id="3ceUhxsVU0Z" role="3clFbG">
               <node concept="2YIFZM" id="3ceUhxsWwZt" role="2Oq$k0">
-                <ref role="37wK5l" to="cg2h:3ceUhxsVM4B" resolve="with" />
+                <ref role="37wK5l" to="cg2h:1OpKexXQv5Y" resolve="with" />
                 <ref role="1Pybhc" to="cg2h:3ceUhxsWt2N" resolve="LogContext" />
                 <node concept="3VsKOn" id="3ceUhxsWwZu" role="37wK5m">
                   <ref role="3VsUkX" node="h19CKg7" resolve="ClassSender" />
@@ -1027,6 +1027,42 @@
                               <ref role="3Tt5mk" to="tpib:4XBaoL6ccco" resolve="project" />
                             </node>
                             <node concept="30H73N" id="3ceUhxsWx0f" role="2Oq$k0" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="10Nm6u" id="1OpKexXQwt2" role="37wK5m">
+                  <node concept="1W57fq" id="1OpKexXQwt3" role="lGtFl">
+                    <node concept="3IZrLx" id="1OpKexXQwt4" role="3IZSJc">
+                      <node concept="3clFbS" id="1OpKexXQwt5" role="2VODD2">
+                        <node concept="3clFbF" id="1OpKexXQwt6" role="3cqZAp">
+                          <node concept="3y3z36" id="1OpKexXQwt7" role="3clFbG">
+                            <node concept="10Nm6u" id="1OpKexXQwt8" role="3uHU7w" />
+                            <node concept="2OqwBi" id="1OpKexXQwt9" role="3uHU7B">
+                              <node concept="30H73N" id="1OpKexXQwta" role="2Oq$k0" />
+                              <node concept="3TrEf2" id="1OpKexXQwtb" role="2OqNvi">
+                                <ref role="3Tt5mk" to="tpib:1OpKexXBmv2" resolve="hintObject" />
+                              </node>
+                            </node>
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="gft3U" id="1OpKexXQwtc" role="UU_$l">
+                      <node concept="10Nm6u" id="1OpKexXQwtd" role="gfFT$" />
+                    </node>
+                  </node>
+                  <node concept="29HgVG" id="1OpKexXQwte" role="lGtFl">
+                    <node concept="3NFfHV" id="1OpKexXQwtf" role="3NFExx">
+                      <node concept="3clFbS" id="1OpKexXQwtg" role="2VODD2">
+                        <node concept="3clFbF" id="1OpKexXQwth" role="3cqZAp">
+                          <node concept="2OqwBi" id="1OpKexXQwti" role="3clFbG">
+                            <node concept="3TrEf2" id="1OpKexXQwtj" role="2OqNvi">
+                              <ref role="3Tt5mk" to="tpib:1OpKexXBmv2" resolve="hint" />
+                            </node>
+                            <node concept="30H73N" id="1OpKexXQwtk" role="2Oq$k0" />
                           </node>
                         </node>
                       </node>

--- a/languages/baseLanguage/logging/jetbrains.mps.baseLanguage.logging.mpl
+++ b/languages/baseLanguage/logging/jetbrains.mps.baseLanguage.logging.mpl
@@ -55,6 +55,7 @@
         <module reference="760a0a8c-eabb-4521-8bfd-65db761a9ba3(jetbrains.mps.baseLanguage.logging)" version="0" />
         <module reference="d95e286a-03bd-41d2-a04d-9db8f070e89c(jetbrains.mps.baseLanguage.logging#1167240554582)" version="0" />
         <module reference="a3e4657f-a76c-45bb-bbda-c764596ecc65(jetbrains.mps.baseLanguage.logging.runtime)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
         <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />

--- a/languages/baseLanguage/logging/languageModels/actions.mps
+++ b/languages/baseLanguage/logging/languageModels/actions.mps
@@ -268,6 +268,24 @@
                   </node>
                 </node>
               </node>
+              <node concept="3clFbF" id="1OpKexXBqpu" role="3cqZAp">
+                <node concept="37vLTI" id="1OpKexXBr0I" role="3clFbG">
+                  <node concept="2OqwBi" id="1OpKexXBr7o" role="37vLTx">
+                    <node concept="Jnkvi" id="1OpKexXBr1d" role="2Oq$k0">
+                      <ref role="1M0zk5" node="5ggSOO4CCYo" resolve="msg" />
+                    </node>
+                    <node concept="3TrEf2" id="1OpKexXBreZ" role="2OqNvi">
+                      <ref role="3Tt5mk" to="tpib:1OpKexXBmv2" resolve="hint" />
+                    </node>
+                  </node>
+                  <node concept="2OqwBi" id="1OpKexXBqAE" role="37vLTJ">
+                    <node concept="1r4Lsj" id="1OpKexXBqpt" role="2Oq$k0" />
+                    <node concept="3TrEf2" id="1OpKexXBqPd" role="2OqNvi">
+                      <ref role="3Tt5mk" to="tpib:1OpKexXBmv2" resolve="hint" />
+                    </node>
+                  </node>
+                </node>
+              </node>
             </node>
             <node concept="JncvC" id="5ggSOO4CCYo" role="JncvA">
               <property role="TrG5h" value="msg" />

--- a/languages/baseLanguage/logging/languageModels/editor.mps
+++ b/languages/baseLanguage/logging/languageModels/editor.mps
@@ -11,7 +11,7 @@
   <imports>
     <import index="tpib" ref="r:00000000-0000-4000-0000-011c8959057f(jetbrains.mps.baseLanguage.logging.structure)" />
     <import index="tpen" ref="r:00000000-0000-4000-0000-011c895902c3(jetbrains.mps.baseLanguage.editor)" />
-    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" implicit="true" />
+    <import index="tpee" ref="r:00000000-0000-4000-0000-011c895902ca(jetbrains.mps.baseLanguage.structure)" />
   </imports>
   <registry>
     <language id="18bc6592-03a6-4e29-a83a-7ff23bde13ba" name="jetbrains.mps.lang.editor">
@@ -820,9 +820,24 @@
           </node>
         </node>
         <node concept="3F1sOY" id="5vyNLjQPtma" role="3EZMnx">
-          <ref role="1NtTu8" to="tpib:4XBaoL6ccco" resolve="project" />
+          <ref role="1NtTu8" to="tpib:1OpKexXBmv2" resolve="hint" />
         </node>
         <node concept="l2Vlx" id="5vyNLjQPtmb" role="2iSdaV" />
+      </node>
+      <node concept="3EZMnI" id="1OpKexXBrrF" role="3EZMnx">
+        <node concept="3F0ifn" id="1OpKexXBrrG" role="3EZMnx">
+          <property role="3F0ifm" value="," />
+          <node concept="VPM3Z" id="1OpKexXBrrH" role="3F10Kt">
+            <property role="VOm3f" value="false" />
+          </node>
+          <node concept="11L4FC" id="1OpKexXBrrI" role="3F10Kt">
+            <property role="VOm3f" value="true" />
+          </node>
+        </node>
+        <node concept="3F1sOY" id="1OpKexXBrrJ" role="3EZMnx">
+          <ref role="1NtTu8" to="tpib:4XBaoL6ccco" resolve="project" />
+        </node>
+        <node concept="l2Vlx" id="1OpKexXBrrK" role="2iSdaV" />
       </node>
       <node concept="3EZMnI" id="5vyNLjQPtmc" role="3EZMnx">
         <node concept="VPM3Z" id="5vyNLjQPtmj" role="3F10Kt">

--- a/languages/baseLanguage/logging/languageModels/structure.mps
+++ b/languages/baseLanguage/logging/languageModels/structure.mps
@@ -147,6 +147,12 @@
       <property role="20kJfa" value="project" />
       <ref role="20lvS9" to="tpee:fz3vP1J" resolve="Expression" />
     </node>
+    <node concept="1TJgyj" id="1OpKexXBmv2" role="1TKVEi">
+      <property role="IQ2ns" value="2096919206290089922" />
+      <property role="20lmBu" value="fLJjDmT/aggregation" />
+      <property role="20kJfa" value="hint" />
+      <ref role="20lvS9" to="tpee:fz3vP1J" resolve="Expression" />
+    </node>
     <node concept="1TJgyi" id="3Ftr4R6BH08" role="1TKVEl">
       <property role="TrG5h" value="severity" />
       <property role="IQ2nx" value="6332851714983843871" />

--- a/languages/baseLanguage/logging/runtime/jetbrains.mps.baseLanguage.logging.runtime.msd
+++ b/languages/baseLanguage/logging/runtime/jetbrains.mps.baseLanguage.logging.runtime.msd
@@ -20,6 +20,7 @@
     <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
     <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
     <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
+    <language slang="l:c7fb639f-be78-4307-89b0-b5959c3fa8c8:jetbrains.mps.lang.text" version="0" />
     <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
   </languageVersions>
   <dependencyVersions>

--- a/languages/baseLanguage/logging/runtime/models/rt.mps
+++ b/languages/baseLanguage/logging/runtime/models/rt.mps
@@ -4,15 +4,21 @@
   <languages>
     <use id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage" version="12" />
     <use id="f2801650-65d5-424e-bb1b-463a8781b786" name="jetbrains.mps.baseLanguage.javadoc" version="2" />
+    <use id="c7fb639f-be78-4307-89b0-b5959c3fa8c8" name="jetbrains.mps.lang.text" version="0" />
   </languages>
   <imports>
     <import index="jtsr" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.project(MPS.OpenAPI/)" />
     <import index="mhfm" ref="3f233e7f-b8a6-46d2-a57f-795d56775243/java:org.jetbrains.annotations(Annotations/)" />
     <import index="wyt6" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.lang(JDK/)" />
     <import index="dr5r" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.util.logging(JDK/)" />
+    <import index="mhbf" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.model(MPS.OpenAPI/)" />
+    <import index="lui2" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.module(MPS.OpenAPI/)" />
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
+        <child id="1082485599096" name="statements" index="9aQI4" />
+      </concept>
       <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
@@ -43,10 +49,18 @@
       <concept id="1081236700937" name="jetbrains.mps.baseLanguage.structure.StaticMethodCall" flags="nn" index="2YIFZM">
         <reference id="1144433194310" name="classConcept" index="1Pybhc" />
       </concept>
+      <concept id="1081256982272" name="jetbrains.mps.baseLanguage.structure.InstanceOfExpression" flags="nn" index="2ZW3vV">
+        <child id="1081256993305" name="classType" index="2ZW6by" />
+        <child id="1081256993304" name="leftExpression" index="2ZW6bz" />
+      </concept>
       <concept id="1070533707846" name="jetbrains.mps.baseLanguage.structure.StaticFieldReference" flags="nn" index="10M0yZ">
         <reference id="1144433057691" name="classifier" index="1PxDUh" />
       </concept>
       <concept id="1070534058343" name="jetbrains.mps.baseLanguage.structure.NullLiteral" flags="nn" index="10Nm6u" />
+      <concept id="1070534934090" name="jetbrains.mps.baseLanguage.structure.CastExpression" flags="nn" index="10QFUN">
+        <child id="1070534934091" name="type" index="10QFUM" />
+        <child id="1070534934092" name="expression" index="10QFUP" />
+      </concept>
       <concept id="1068390468200" name="jetbrains.mps.baseLanguage.structure.FieldDeclaration" flags="ig" index="312cEg" />
       <concept id="1068390468198" name="jetbrains.mps.baseLanguage.structure.ClassConcept" flags="ig" index="312cEu">
         <property id="1221565133444" name="isFinal" index="1EXbeo" />
@@ -77,6 +91,11 @@
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
       </concept>
+      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
+        <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
+        <child id="1068580123160" name="condition" index="3clFbw" />
+        <child id="1068580123161" name="ifTrue" index="3clFbx" />
+      </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
       </concept>
@@ -89,6 +108,9 @@
       </concept>
       <concept id="1068581242863" name="jetbrains.mps.baseLanguage.structure.LocalVariableDeclaration" flags="nr" index="3cpWsn" />
       <concept id="1068581517677" name="jetbrains.mps.baseLanguage.structure.VoidType" flags="in" index="3cqZAl" />
+      <concept id="1079359253375" name="jetbrains.mps.baseLanguage.structure.ParenthesizedExpression" flags="nn" index="1eOMI4">
+        <child id="1079359253376" name="expression" index="1eOMHV" />
+      </concept>
       <concept id="1154542696413" name="jetbrains.mps.baseLanguage.structure.ArrayCreatorWithInitializer" flags="nn" index="3g6Rrh">
         <child id="1154542793668" name="componentType" index="3g7fb8" />
         <child id="1154542803372" name="initValue" index="3g7hyw" />
@@ -484,13 +506,119 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="1OpKexXQmFq" role="3cqZAp">
-          <node concept="37vLTI" id="1OpKexXQmFs" role="3clFbG">
-            <node concept="37vLTw" id="1OpKexXQmFv" role="37vLTJ">
-              <ref role="3cqZAo" node="1OpKexXQmFm" resolve="myHint" />
-            </node>
-            <node concept="37vLTw" id="1OpKexXQmFw" role="37vLTx">
+        <node concept="3clFbJ" id="1OpKexXS5UL" role="3cqZAp">
+          <node concept="2ZW3vV" id="1OpKexXS5UO" role="3clFbw">
+            <node concept="37vLTw" id="1OpKexXS5UM" role="2ZW6bz">
               <ref role="3cqZAo" node="1OpKexXQm5d" resolve="hint" />
+            </node>
+            <node concept="3uibUv" id="1OpKexXS5UN" role="2ZW6by">
+              <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+            </node>
+          </node>
+          <node concept="3clFbJ" id="1OpKexXS5UZ" role="9aQIa">
+            <node concept="2ZW3vV" id="1OpKexXS5V2" role="3clFbw">
+              <node concept="37vLTw" id="1OpKexXS5V0" role="2ZW6bz">
+                <ref role="3cqZAo" node="1OpKexXQm5d" resolve="hint" />
+              </node>
+              <node concept="3uibUv" id="1OpKexXS5V1" role="2ZW6by">
+                <ref role="3uigEE" to="mhbf:~SModel" resolve="SModel" />
+              </node>
+            </node>
+            <node concept="3clFbJ" id="1OpKexXS5Vd" role="9aQIa">
+              <node concept="2ZW3vV" id="1OpKexXS5Vg" role="3clFbw">
+                <node concept="37vLTw" id="1OpKexXS5Ve" role="2ZW6bz">
+                  <ref role="3cqZAo" node="1OpKexXQm5d" resolve="hint" />
+                </node>
+                <node concept="3uibUv" id="1OpKexXS5Vf" role="2ZW6by">
+                  <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
+                </node>
+              </node>
+              <node concept="9aQIb" id="1OpKexXS5Vr" role="9aQIa">
+                <node concept="3clFbS" id="1OpKexXS5Vs" role="9aQI4">
+                  <node concept="3clFbF" id="1OpKexXS5Vt" role="3cqZAp">
+                    <node concept="37vLTI" id="1OpKexXS5Vu" role="3clFbG">
+                      <node concept="37vLTw" id="1OpKexXS5Vv" role="37vLTJ">
+                        <ref role="3cqZAo" node="1OpKexXQmFm" resolve="myHint" />
+                      </node>
+                      <node concept="37vLTw" id="1OpKexXS5Vw" role="37vLTx">
+                        <ref role="3cqZAo" node="1OpKexXQm5d" resolve="hint" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbS" id="1OpKexXS5Vi" role="3clFbx">
+                <node concept="3clFbF" id="1OpKexXS5Vj" role="3cqZAp">
+                  <node concept="37vLTI" id="1OpKexXS5Vk" role="3clFbG">
+                    <node concept="37vLTw" id="1OpKexXS5Vl" role="37vLTJ">
+                      <ref role="3cqZAo" node="1OpKexXQmFm" resolve="myHint" />
+                    </node>
+                    <node concept="2OqwBi" id="1OpKexXS9kK" role="37vLTx">
+                      <node concept="1eOMI4" id="1OpKexXS5Vq" role="2Oq$k0">
+                        <node concept="10QFUN" id="1OpKexXS5Vn" role="1eOMHV">
+                          <node concept="37vLTw" id="1OpKexXS5Vo" role="10QFUP">
+                            <ref role="3cqZAo" node="1OpKexXQm5d" resolve="hint" />
+                          </node>
+                          <node concept="3uibUv" id="1OpKexXS5Vp" role="10QFUM">
+                            <ref role="3uigEE" to="lui2:~SModule" resolve="SModule" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="1OpKexXS9kL" role="2OqNvi">
+                        <ref role="37wK5l" to="lui2:~SModule.getModuleReference()" resolve="getModuleReference" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbS" id="1OpKexXS5V4" role="3clFbx">
+              <node concept="3clFbF" id="1OpKexXS5V5" role="3cqZAp">
+                <node concept="37vLTI" id="1OpKexXS5V6" role="3clFbG">
+                  <node concept="37vLTw" id="1OpKexXS5V7" role="37vLTJ">
+                    <ref role="3cqZAo" node="1OpKexXQmFm" resolve="myHint" />
+                  </node>
+                  <node concept="2OqwBi" id="1OpKexXS6LL" role="37vLTx">
+                    <node concept="1eOMI4" id="1OpKexXS5Vc" role="2Oq$k0">
+                      <node concept="10QFUN" id="1OpKexXS5V9" role="1eOMHV">
+                        <node concept="37vLTw" id="1OpKexXS5Va" role="10QFUP">
+                          <ref role="3cqZAo" node="1OpKexXQm5d" resolve="hint" />
+                        </node>
+                        <node concept="3uibUv" id="1OpKexXS5Vb" role="10QFUM">
+                          <ref role="3uigEE" to="mhbf:~SModel" resolve="SModel" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="1OpKexXS6LM" role="2OqNvi">
+                      <ref role="37wK5l" to="mhbf:~SModel.getReference()" resolve="getReference" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbS" id="1OpKexXS5UQ" role="3clFbx">
+            <node concept="3clFbF" id="1OpKexXS5UR" role="3cqZAp">
+              <node concept="37vLTI" id="1OpKexXS5US" role="3clFbG">
+                <node concept="37vLTw" id="1OpKexXS5UT" role="37vLTJ">
+                  <ref role="3cqZAo" node="1OpKexXQmFm" resolve="myHint" />
+                </node>
+                <node concept="2OqwBi" id="1OpKexXS6Rx" role="37vLTx">
+                  <node concept="1eOMI4" id="1OpKexXS5UY" role="2Oq$k0">
+                    <node concept="10QFUN" id="1OpKexXS5UV" role="1eOMHV">
+                      <node concept="37vLTw" id="1OpKexXS5UW" role="10QFUP">
+                        <ref role="3cqZAo" node="1OpKexXQm5d" resolve="hint" />
+                      </node>
+                      <node concept="3uibUv" id="1OpKexXS5UX" role="10QFUM">
+                        <ref role="3uigEE" to="mhbf:~SNode" resolve="SNode" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="1OpKexXS6Ry" role="2OqNvi">
+                    <ref role="37wK5l" to="mhbf:~SNode.getReference()" resolve="getReference" />
+                  </node>
+                </node>
+              </node>
             </node>
           </node>
         </node>

--- a/languages/baseLanguage/logging/runtime/models/rt.mps
+++ b/languages/baseLanguage/logging/runtime/models/rt.mps
@@ -13,9 +13,6 @@
   </imports>
   <registry>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
-      <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
-        <child id="1082485599096" name="statements" index="9aQI4" />
-      </concept>
       <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
@@ -77,14 +74,8 @@
         <child id="1068580123135" name="body" index="3clF47" />
       </concept>
       <concept id="1068580123165" name="jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" flags="ig" index="3clFb_" />
-      <concept id="1068580123152" name="jetbrains.mps.baseLanguage.structure.EqualsExpression" flags="nn" index="3clFbC" />
       <concept id="1068580123155" name="jetbrains.mps.baseLanguage.structure.ExpressionStatement" flags="nn" index="3clFbF">
         <child id="1068580123156" name="expression" index="3clFbG" />
-      </concept>
-      <concept id="1068580123159" name="jetbrains.mps.baseLanguage.structure.IfStatement" flags="nn" index="3clFbJ">
-        <child id="1082485599094" name="ifFalseStatement" index="9aQIa" />
-        <child id="1068580123160" name="condition" index="3clFbw" />
-        <child id="1068580123161" name="ifTrue" index="3clFbx" />
       </concept>
       <concept id="1068580123136" name="jetbrains.mps.baseLanguage.structure.StatementList" flags="sn" stub="5293379017992965193" index="3clFbS">
         <child id="1068581517665" name="statement" index="3cqZAp" />
@@ -115,10 +106,6 @@
       <concept id="1107535904670" name="jetbrains.mps.baseLanguage.structure.ClassifierType" flags="in" index="3uibUv">
         <reference id="1107535924139" name="classifier" index="3uigEE" />
         <child id="1109201940907" name="parameter" index="11_B2D" />
-      </concept>
-      <concept id="1081773326031" name="jetbrains.mps.baseLanguage.structure.BinaryOperation" flags="nn" index="3uHJSO">
-        <child id="1081773367579" name="rightExpression" index="3uHU7w" />
-        <child id="1081773367580" name="leftExpression" index="3uHU7B" />
       </concept>
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
@@ -294,12 +281,84 @@
               <node concept="37vLTw" id="3ceUhxsVQSL" role="37wK5m">
                 <ref role="3cqZAo" node="3ceUhxsVMip" resolve="project" />
               </node>
+              <node concept="10Nm6u" id="1OpKexXQv$k" role="37wK5m" />
             </node>
           </node>
         </node>
       </node>
       <node concept="3Tm1VV" id="3ceUhxsVLRr" role="1B3o_S" />
       <node concept="3uibUv" id="3ceUhxsVMha" role="3clF45">
+        <ref role="3uigEE" node="3ceUhxsVKjJ" resolve="Log" />
+      </node>
+    </node>
+    <node concept="2YIFZL" id="1OpKexXQv5Y" role="jymVt">
+      <property role="TrG5h" value="with" />
+      <node concept="37vLTG" id="1OpKexXQv5Z" role="3clF46">
+        <property role="TrG5h" value="sender" />
+        <node concept="3uibUv" id="1OpKexXQv60" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~Class" resolve="Class" />
+          <node concept="3qTvmN" id="1OpKexXQv61" role="11_B2D" />
+        </node>
+        <node concept="2AHcQZ" id="1OpKexXQv62" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~NotNull" resolve="NotNull" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="1OpKexXQv63" role="3clF46">
+        <property role="TrG5h" value="throwable" />
+        <node concept="3uibUv" id="1OpKexXQv64" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~Throwable" resolve="Throwable" />
+        </node>
+        <node concept="2AHcQZ" id="1OpKexXQv65" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="1OpKexXQv66" role="3clF46">
+        <property role="TrG5h" value="project" />
+        <node concept="3uibUv" id="1OpKexXQv67" role="1tU5fm">
+          <ref role="3uigEE" to="jtsr:~Project" resolve="Project" />
+        </node>
+        <node concept="2AHcQZ" id="1OpKexXQv68" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="1OpKexXQv69" role="3clF46">
+        <property role="TrG5h" value="hint" />
+        <node concept="3uibUv" id="1OpKexXQv6a" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+        </node>
+        <node concept="2AHcQZ" id="1OpKexXQv6b" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+        </node>
+      </node>
+      <node concept="3clFbS" id="1OpKexXQv6c" role="3clF47">
+        <node concept="3cpWs6" id="1OpKexXQv6d" role="3cqZAp">
+          <node concept="2ShNRf" id="1OpKexXQv6e" role="3cqZAk">
+            <node concept="1pGfFk" id="1OpKexXQv6f" role="2ShVmc">
+              <property role="373rjd" value="true" />
+              <ref role="37wK5l" node="3ceUhxsVOS4" resolve="LogCtx" />
+              <node concept="2OqwBi" id="1OpKexXQv6g" role="37wK5m">
+                <node concept="37vLTw" id="1OpKexXQv6h" role="2Oq$k0">
+                  <ref role="3cqZAo" node="1OpKexXQv5Z" resolve="sender" />
+                </node>
+                <node concept="liA8E" id="1OpKexXQv6i" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~Class.toString()" resolve="toString" />
+                </node>
+              </node>
+              <node concept="37vLTw" id="1OpKexXQv6j" role="37wK5m">
+                <ref role="3cqZAo" node="1OpKexXQv63" resolve="throwable" />
+              </node>
+              <node concept="37vLTw" id="1OpKexXQv6k" role="37wK5m">
+                <ref role="3cqZAo" node="1OpKexXQv66" resolve="project" />
+              </node>
+              <node concept="37vLTw" id="1OpKexXQv6l" role="37wK5m">
+                <ref role="3cqZAo" node="1OpKexXQv69" resolve="hint" />
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="1OpKexXQv6m" role="1B3o_S" />
+      <node concept="3uibUv" id="1OpKexXQv6n" role="3clF45">
         <ref role="3uigEE" node="3ceUhxsVKjJ" resolve="Log" />
       </node>
     </node>
@@ -349,6 +408,14 @@
         <ref role="3uigEE" to="jtsr:~Project" resolve="Project" />
       </node>
     </node>
+    <node concept="312cEg" id="1OpKexXQmFm" role="jymVt">
+      <property role="TrG5h" value="myHint" />
+      <property role="3TUv4t" value="true" />
+      <node concept="3Tm6S6" id="1OpKexXQmFn" role="1B3o_S" />
+      <node concept="3uibUv" id="1OpKexXQmFp" role="1tU5fm">
+        <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+      </node>
+    </node>
     <node concept="2tJIrI" id="3ceUhxsVPks" role="jymVt" />
     <node concept="3clFbW" id="3ceUhxsVOS4" role="jymVt">
       <node concept="37vLTG" id="3ceUhxsVOTp" role="3clF46">
@@ -373,6 +440,15 @@
           <ref role="3uigEE" to="jtsr:~Project" resolve="Project" />
         </node>
         <node concept="2AHcQZ" id="3ceUhxsVOTy" role="2AJF6D">
+          <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
+        </node>
+      </node>
+      <node concept="37vLTG" id="1OpKexXQm5d" role="3clF46">
+        <property role="TrG5h" value="hint" />
+        <node concept="3uibUv" id="1OpKexXQm5e" role="1tU5fm">
+          <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
+        </node>
+        <node concept="2AHcQZ" id="1OpKexXQm5f" role="2AJF6D">
           <ref role="2AI5Lk" to="mhfm:~Nullable" resolve="Nullable" />
         </node>
       </node>
@@ -405,6 +481,16 @@
             </node>
             <node concept="37vLTw" id="3ceUhxsVPgY" role="37vLTx">
               <ref role="3cqZAo" node="3ceUhxsVOTw" resolve="project" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="1OpKexXQmFq" role="3cqZAp">
+          <node concept="37vLTI" id="1OpKexXQmFs" role="3clFbG">
+            <node concept="37vLTw" id="1OpKexXQmFv" role="37vLTJ">
+              <ref role="3cqZAo" node="1OpKexXQmFm" resolve="myHint" />
+            </node>
+            <node concept="37vLTw" id="1OpKexXQmFw" role="37vLTx">
+              <ref role="3cqZAo" node="1OpKexXQm5d" resolve="hint" />
             </node>
           </node>
         </node>
@@ -519,57 +605,26 @@
             </node>
           </node>
         </node>
-        <node concept="3clFbJ" id="5HsyGcAPpDz" role="3cqZAp">
-          <node concept="3clFbS" id="5HsyGcAPpD_" role="3clFbx">
-            <node concept="3clFbF" id="5HsyGcAPovO" role="3cqZAp">
-              <node concept="2OqwBi" id="5HsyGcAPoSb" role="3clFbG">
-                <node concept="37vLTw" id="5HsyGcAPovM" role="2Oq$k0">
-                  <ref role="3cqZAo" node="5HsyGcAPetl" resolve="lr" />
-                </node>
-                <node concept="liA8E" id="5HsyGcAPp8z" role="2OqNvi">
-                  <ref role="37wK5l" to="dr5r:~LogRecord.setParameters(java.lang.Object[])" resolve="setParameters" />
-                  <node concept="2ShNRf" id="5HsyGcAPrcz" role="37wK5m">
-                    <node concept="3g6Rrh" id="5HsyGcAPser" role="2ShVmc">
-                      <node concept="3uibUv" id="5HsyGcAPrQl" role="3g7fb8">
-                        <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-                      </node>
-                      <node concept="37vLTw" id="5HsyGcAPstP" role="3g7hyw">
-                        <ref role="3cqZAo" node="3ceUhxsVP5Z" resolve="mySender" />
-                      </node>
-                    </node>
-                  </node>
-                </node>
-              </node>
+        <node concept="3clFbF" id="1OpKexXQp2W" role="3cqZAp">
+          <node concept="2OqwBi" id="1OpKexXQpj9" role="3clFbG">
+            <node concept="37vLTw" id="1OpKexXQp2U" role="2Oq$k0">
+              <ref role="3cqZAo" node="5HsyGcAPetl" resolve="lr" />
             </node>
-          </node>
-          <node concept="3clFbC" id="5HsyGcAPqeF" role="3clFbw">
-            <node concept="10Nm6u" id="5HsyGcAPqtc" role="3uHU7w" />
-            <node concept="37vLTw" id="5HsyGcAPpW$" role="3uHU7B">
-              <ref role="3cqZAo" node="3ceUhxsVPgO" resolve="myProject" />
-            </node>
-          </node>
-          <node concept="9aQIb" id="5HsyGcAPsGJ" role="9aQIa">
-            <node concept="3clFbS" id="5HsyGcAPsGK" role="9aQI4">
-              <node concept="3clFbF" id="5HsyGcAPsVB" role="3cqZAp">
-                <node concept="2OqwBi" id="5HsyGcAPsVC" role="3clFbG">
-                  <node concept="37vLTw" id="5HsyGcAPsVD" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5HsyGcAPetl" resolve="lr" />
+            <node concept="liA8E" id="1OpKexXQpGW" role="2OqNvi">
+              <ref role="37wK5l" to="dr5r:~LogRecord.setParameters(java.lang.Object[])" resolve="setParameters" />
+              <node concept="2ShNRf" id="1OpKexXQpZ6" role="37wK5m">
+                <node concept="3g6Rrh" id="1OpKexXQsdm" role="2ShVmc">
+                  <node concept="3uibUv" id="1OpKexXQrK4" role="3g7fb8">
+                    <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
                   </node>
-                  <node concept="liA8E" id="5HsyGcAPsVE" role="2OqNvi">
-                    <ref role="37wK5l" to="dr5r:~LogRecord.setParameters(java.lang.Object[])" resolve="setParameters" />
-                    <node concept="2ShNRf" id="5HsyGcAPsVF" role="37wK5m">
-                      <node concept="3g6Rrh" id="5HsyGcAPsVG" role="2ShVmc">
-                        <node concept="3uibUv" id="5HsyGcAPsVH" role="3g7fb8">
-                          <ref role="3uigEE" to="wyt6:~Object" resolve="Object" />
-                        </node>
-                        <node concept="37vLTw" id="5HsyGcAPsVI" role="3g7hyw">
-                          <ref role="3cqZAo" node="3ceUhxsVP5Z" resolve="mySender" />
-                        </node>
-                        <node concept="37vLTw" id="5HsyGcAPtJX" role="3g7hyw">
-                          <ref role="3cqZAo" node="3ceUhxsVPgO" resolve="myProject" />
-                        </node>
-                      </node>
-                    </node>
+                  <node concept="37vLTw" id="1OpKexXQsv8" role="3g7hyw">
+                    <ref role="3cqZAo" node="3ceUhxsVP5Z" resolve="mySender" />
+                  </node>
+                  <node concept="37vLTw" id="1OpKexXQt2w" role="3g7hyw">
+                    <ref role="3cqZAo" node="3ceUhxsVPgO" resolve="myProject" />
+                  </node>
+                  <node concept="37vLTw" id="1OpKexXQt_B" role="3g7hyw">
+                    <ref role="3cqZAo" node="1OpKexXQmFm" resolve="myHint" />
                   </node>
                 </node>
               </node>

--- a/languages/baseLanguage/logging/runtime/source_gen.caches/jetbrains/mps/baseLanguage/logging/rt/generated
+++ b/languages/baseLanguage/logging/runtime/source_gen.caches/jetbrains/mps/baseLanguage/logging/rt/generated
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<product version="3" modelHash="-epbja5d3el5gr05g9sr8hg5ia1c1gdl">
+<product version="3" modelHash="-40qw9iv4udurm0o592k9entfb6980zs">
   <files names="Log.java:LogContext.java:LogCtx.java" />
 </product>
 

--- a/languages/baseLanguage/logging/runtime/source_gen.caches/jetbrains/mps/baseLanguage/logging/rt/generated
+++ b/languages/baseLanguage/logging/runtime/source_gen.caches/jetbrains/mps/baseLanguage/logging/rt/generated
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<product version="3" modelHash="bqv2oxcixxppng2zmrzr2273of4dp65">
+<product version="3" modelHash="-epbja5d3el5gr05g9sr8hg5ia1c1gdl">
   <files names="Log.java:LogContext.java:LogCtx.java" />
 </product>
 

--- a/languages/baseLanguage/logging/runtime/source_gen/jetbrains/mps/baseLanguage/logging/rt/LogContext.java
+++ b/languages/baseLanguage/logging/runtime/source_gen/jetbrains/mps/baseLanguage/logging/rt/LogContext.java
@@ -11,6 +11,9 @@ import org.jetbrains.mps.openapi.project.Project;
  */
 public class LogContext {
   public static Log with(@NotNull Class<?> sender, @Nullable Throwable throwable, @Nullable Project project) {
-    return new LogCtx(sender.toString(), throwable, project);
+    return new LogCtx(sender.toString(), throwable, project, null);
+  }
+  public static Log with(@NotNull Class<?> sender, @Nullable Throwable throwable, @Nullable Project project, @Nullable Object hint) {
+    return new LogCtx(sender.toString(), throwable, project, hint);
   }
 }

--- a/languages/baseLanguage/logging/runtime/source_gen/jetbrains/mps/baseLanguage/logging/rt/LogCtx.java
+++ b/languages/baseLanguage/logging/runtime/source_gen/jetbrains/mps/baseLanguage/logging/rt/LogCtx.java
@@ -5,6 +5,9 @@ package jetbrains.mps.baseLanguage.logging.rt;
 import org.jetbrains.mps.openapi.project.Project;
 import org.jetbrains.annotations.NotNull;
 import org.jetbrains.annotations.Nullable;
+import org.jetbrains.mps.openapi.model.SNode;
+import org.jetbrains.mps.openapi.model.SModel;
+import org.jetbrains.mps.openapi.module.SModule;
 import java.util.logging.Level;
 import java.util.logging.LogRecord;
 import java.util.logging.Logger;
@@ -21,7 +24,17 @@ import java.util.logging.Logger;
     mySender = sender;
     myException = exception;
     myProject = project;
-    myHint = hint;
+    if (hint instanceof SNode) {
+      myHint = ((SNode) hint).getReference();
+    } else
+    if (hint instanceof SModel) {
+      myHint = ((SModel) hint).getReference();
+    } else
+    if (hint instanceof SModule) {
+      myHint = ((SModule) hint).getModuleReference();
+    } else {
+      myHint = hint;
+    }
   }
 
   private void _log(Level level, Object msg) {

--- a/languages/baseLanguage/logging/runtime/source_gen/jetbrains/mps/baseLanguage/logging/rt/LogCtx.java
+++ b/languages/baseLanguage/logging/runtime/source_gen/jetbrains/mps/baseLanguage/logging/rt/LogCtx.java
@@ -15,11 +15,13 @@ import java.util.logging.Logger;
   private final String mySender;
   private final Throwable myException;
   private final Project myProject;
+  private final Object myHint;
 
-  /*package*/ LogCtx(@NotNull String sender, @Nullable Throwable exception, @Nullable Project project) {
+  /*package*/ LogCtx(@NotNull String sender, @Nullable Throwable exception, @Nullable Project project, @Nullable Object hint) {
     mySender = sender;
     myException = exception;
     myProject = project;
+    myHint = hint;
   }
 
   private void _log(Level level, Object msg) {
@@ -27,11 +29,7 @@ import java.util.logging.Logger;
     // j.m.logging.Logger wrap
     LogRecord lr = new LogRecord(level, String.valueOf(msg));
     lr.setThrown(myException);
-    if (myProject == null) {
-      lr.setParameters(new Object[]{mySender});
-    } else {
-      lr.setParameters(new Object[]{mySender, myProject});
-    }
+    lr.setParameters(new Object[]{mySender, myProject, myHint});
     Logger.getLogger(MSG_VIEW_TOKEN).log(lr);
   }
 

--- a/languages/baseLanguage/logging/runtime/source_gen/jetbrains/mps/baseLanguage/logging/rt/trace.info
+++ b/languages/baseLanguage/logging/runtime/source_gen/jetbrains/mps/baseLanguage/logging/rt/trace.info
@@ -1,8 +1,10 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <debug-info version="2">
+  <concept fqn="c:f3061a53-9226-4cc5-a443-f952ceaf5816/1082485599095:jetbrains.mps.baseLanguage.structure.BlockStatement" />
   <concept fqn="c:f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123140:jetbrains.mps.baseLanguage.structure.ConstructorDeclaration" />
   <concept fqn="c:f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123155:jetbrains.mps.baseLanguage.structure.ExpressionStatement" />
   <concept fqn="c:f3061a53-9226-4cc5-a443-f952ceaf5816/1068390468200:jetbrains.mps.baseLanguage.structure.FieldDeclaration" />
+  <concept fqn="c:f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123159:jetbrains.mps.baseLanguage.structure.IfStatement" />
   <concept fqn="c:f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123165:jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" />
   <concept fqn="c:f3061a53-9226-4cc5-a443-f952ceaf5816/1068581242864:jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" />
   <concept fqn="c:f3061a53-9226-4cc5-a443-f952ceaf5816/1068581242878:jetbrains.mps.baseLanguage.structure.ReturnStatement" />
@@ -11,12 +13,12 @@
   <concept fqn="c:f3061a53-9226-4cc5-a443-f952ceaf5816/1081236700938:jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" />
   <root nodeRef="r:cc7bd7ff-ad7f-43d6-97d1-d660e55b3d10(jetbrains.mps.baseLanguage.logging.rt)/3679134236455929071">
     <file name="Log.java">
-      <node id="3679134236455932153" at="10,0,11,0" concept="3" trace="fatal#(Ljava/lang/Object;)V" />
-      <node id="3679134236455932668" at="11,0,12,0" concept="3" trace="error#(Ljava/lang/Object;)V" />
-      <node id="3679134236455933114" at="12,0,13,0" concept="3" trace="warning#(Ljava/lang/Object;)V" />
-      <node id="3679134236455933420" at="13,0,14,0" concept="3" trace="info#(Ljava/lang/Object;)V" />
-      <node id="3679134236455933812" at="14,0,15,0" concept="3" trace="debug#(Ljava/lang/Object;)V" />
-      <node id="3679134236455934290" at="15,0,16,0" concept="3" trace="trace#(Ljava/lang/Object;)V" />
+      <node id="3679134236455932153" at="10,0,11,0" concept="5" trace="fatal#(Ljava/lang/Object;)V" />
+      <node id="3679134236455932668" at="11,0,12,0" concept="5" trace="error#(Ljava/lang/Object;)V" />
+      <node id="3679134236455933114" at="12,0,13,0" concept="5" trace="warning#(Ljava/lang/Object;)V" />
+      <node id="3679134236455933420" at="13,0,14,0" concept="5" trace="info#(Ljava/lang/Object;)V" />
+      <node id="3679134236455933812" at="14,0,15,0" concept="5" trace="debug#(Ljava/lang/Object;)V" />
+      <node id="3679134236455934290" at="15,0,16,0" concept="5" trace="trace#(Ljava/lang/Object;)V" />
       <scope id="3679134236455932153" at="10,0,11,0">
         <var name="msg" id="3679134236455932214" />
       </scope>
@@ -40,82 +42,93 @@
   </root>
   <root nodeRef="r:cc7bd7ff-ad7f-43d6-97d1-d660e55b3d10(jetbrains.mps.baseLanguage.logging.rt)/3679134236455946004">
     <file name="LogCtx.java">
-      <node id="5721587534047579222" at="13,0,14,0" concept="7" trace="MSG_VIEW_TOKEN" />
-      <node id="3679134236455948671" at="15,0,16,0" concept="2" trace="mySender" />
-      <node id="3679134236455949116" at="16,0,17,0" concept="2" trace="myException" />
-      <node id="3679134236455949364" at="17,0,18,0" concept="2" trace="myProject" />
-      <node id="2096919206294022870" at="18,0,19,0" concept="2" trace="myHint" />
-      <node id="3679134236455948675" at="20,127,21,22" concept="1" />
-      <node id="3679134236455949120" at="21,22,22,28" concept="1" />
-      <node id="3679134236455949368" at="22,28,23,24" concept="1" />
-      <node id="2096919206294022874" at="23,24,24,18" concept="1" />
-      <node id="6583289326083632563" at="27,46,28,101" concept="6" />
-      <node id="6583289326083635098" at="28,101,29,30" concept="6" />
-      <node id="6583289326083565396" at="29,30,30,61" concept="4" />
-      <node id="6583289326083582190" at="30,61,31,30" concept="1" />
-      <node id="2096919206294032572" at="31,30,32,64" concept="1" />
-      <node id="3679134236456145564" at="32,64,33,45" concept="1" />
-      <node id="3679134236456170790" at="37,33,38,28" concept="1" />
-      <node id="3679134236456176023" at="41,33,42,28" concept="1" />
-      <node id="3679134236456178250" at="45,35,46,29" concept="1" />
-      <node id="3679134236456178994" at="49,32,50,26" concept="1" />
-      <node id="3679134236456180264" at="53,33,54,26" concept="1" />
-      <node id="3679134236456181090" at="57,33,58,28" concept="1" />
-      <node id="3679134236455950050" at="36,0,40,0" concept="3" trace="fatal#(Ljava/lang/Object;)V" />
-      <node id="3679134236455950058" at="40,0,44,0" concept="3" trace="error#(Ljava/lang/Object;)V" />
-      <node id="3679134236455950066" at="44,0,48,0" concept="3" trace="warning#(Ljava/lang/Object;)V" />
-      <node id="3679134236455950074" at="48,0,52,0" concept="3" trace="info#(Ljava/lang/Object;)V" />
-      <node id="3679134236455950082" at="52,0,56,0" concept="3" trace="debug#(Ljava/lang/Object;)V" />
-      <node id="3679134236455950090" at="56,0,60,0" concept="3" trace="trace#(Ljava/lang/Object;)V" />
-      <node id="3679134236455947780" at="20,0,26,0" concept="0" trace="LogCtx#(Ljava/lang/String;Ljava/lang/Throwable;Lorg/jetbrains/mps/openapi/project/Project;Ljava/lang/Object;)V" />
-      <node id="3679134236456133570" at="27,0,35,0" concept="3" trace="_log#(Ljava/util/logging/Level;Ljava/lang/Object;)V" />
-      <scope id="3679134236455950056" at="37,33,38,28" />
-      <scope id="3679134236455950064" at="41,33,42,28" />
-      <scope id="3679134236455950072" at="45,35,46,29" />
-      <scope id="3679134236455950080" at="49,32,50,26" />
-      <scope id="3679134236455950088" at="53,33,54,26" />
-      <scope id="3679134236455950096" at="57,33,58,28" />
-      <scope id="3679134236455947784" at="20,127,24,18" />
-      <scope id="3679134236455950050" at="36,0,40,0">
+      <node id="5721587534047579222" at="16,0,17,0" concept="9" trace="MSG_VIEW_TOKEN" />
+      <node id="3679134236455948671" at="18,0,19,0" concept="3" trace="mySender" />
+      <node id="3679134236455949116" at="19,0,20,0" concept="3" trace="myException" />
+      <node id="3679134236455949364" at="20,0,21,0" concept="3" trace="myProject" />
+      <node id="2096919206294022870" at="21,0,22,0" concept="3" trace="myHint" />
+      <node id="3679134236455948675" at="23,127,24,22" concept="2" />
+      <node id="3679134236455949120" at="24,22,25,28" concept="2" />
+      <node id="3679134236455949368" at="25,28,26,24" concept="2" />
+      <node id="2096919206294478519" at="27,32,28,45" concept="2" />
+      <node id="2096919206294478533" at="30,33,31,46" concept="2" />
+      <node id="2096919206294478547" at="33,34,34,53" concept="2" />
+      <node id="2096919206294478557" at="35,12,36,20" concept="2" />
+      <node id="6583289326083632563" at="40,46,41,101" concept="8" />
+      <node id="6583289326083635098" at="41,101,42,30" concept="8" />
+      <node id="6583289326083565396" at="42,30,43,61" concept="6" />
+      <node id="6583289326083582190" at="43,61,44,30" concept="2" />
+      <node id="2096919206294032572" at="44,30,45,64" concept="2" />
+      <node id="3679134236456145564" at="45,64,46,45" concept="2" />
+      <node id="3679134236456170790" at="50,33,51,28" concept="2" />
+      <node id="3679134236456176023" at="54,33,55,28" concept="2" />
+      <node id="3679134236456178250" at="58,35,59,29" concept="2" />
+      <node id="3679134236456178994" at="62,32,63,26" concept="2" />
+      <node id="3679134236456180264" at="66,33,67,26" concept="2" />
+      <node id="3679134236456181090" at="70,33,71,28" concept="2" />
+      <node id="2096919206294478555" at="35,10,37,5" concept="0" />
+      <node id="3679134236455950050" at="49,0,53,0" concept="5" trace="fatal#(Ljava/lang/Object;)V" />
+      <node id="3679134236455950058" at="53,0,57,0" concept="5" trace="error#(Ljava/lang/Object;)V" />
+      <node id="3679134236455950066" at="57,0,61,0" concept="5" trace="warning#(Ljava/lang/Object;)V" />
+      <node id="3679134236455950074" at="61,0,65,0" concept="5" trace="info#(Ljava/lang/Object;)V" />
+      <node id="3679134236455950082" at="65,0,69,0" concept="5" trace="debug#(Ljava/lang/Object;)V" />
+      <node id="3679134236455950090" at="69,0,73,0" concept="5" trace="trace#(Ljava/lang/Object;)V" />
+      <node id="2096919206294478541" at="32,10,37,5" concept="4" />
+      <node id="2096919206294478527" at="29,10,37,5" concept="4" />
+      <node id="3679134236456133570" at="40,0,48,0" concept="5" trace="_log#(Ljava/util/logging/Level;Ljava/lang/Object;)V" />
+      <node id="2096919206294478513" at="26,24,37,5" concept="4" />
+      <node id="3679134236455947780" at="23,0,39,0" concept="1" trace="LogCtx#(Ljava/lang/String;Ljava/lang/Throwable;Lorg/jetbrains/mps/openapi/project/Project;Ljava/lang/Object;)V" />
+      <scope id="2096919206294478518" at="27,32,28,45" />
+      <scope id="2096919206294478532" at="30,33,31,46" />
+      <scope id="2096919206294478546" at="33,34,34,53" />
+      <scope id="2096919206294478556" at="35,12,36,20" />
+      <scope id="3679134236455950056" at="50,33,51,28" />
+      <scope id="3679134236455950064" at="54,33,55,28" />
+      <scope id="3679134236455950072" at="58,35,59,29" />
+      <scope id="3679134236455950080" at="62,32,63,26" />
+      <scope id="3679134236455950088" at="66,33,67,26" />
+      <scope id="3679134236455950096" at="70,33,71,28" />
+      <scope id="3679134236455950050" at="49,0,53,0">
         <var name="msg" id="3679134236455950054" />
       </scope>
-      <scope id="3679134236455950058" at="40,0,44,0">
+      <scope id="3679134236455950058" at="53,0,57,0">
         <var name="msg" id="3679134236455950059" />
       </scope>
-      <scope id="3679134236455950066" at="44,0,48,0">
+      <scope id="3679134236455950066" at="57,0,61,0">
         <var name="msg" id="3679134236455950067" />
       </scope>
-      <scope id="3679134236455950074" at="48,0,52,0">
+      <scope id="3679134236455950074" at="61,0,65,0">
         <var name="msg" id="3679134236455950075" />
       </scope>
-      <scope id="3679134236455950082" at="52,0,56,0">
+      <scope id="3679134236455950082" at="65,0,69,0">
         <var name="msg" id="3679134236455950083" />
       </scope>
-      <scope id="3679134236455950090" at="56,0,60,0">
+      <scope id="3679134236455950090" at="69,0,73,0">
         <var name="msg" id="3679134236455950091" />
       </scope>
-      <scope id="3679134236455947780" at="20,0,26,0">
+      <scope id="3679134236456133573" at="40,46,46,45">
+        <var name="lr" id="6583289326083565397" />
+      </scope>
+      <scope id="3679134236456133570" at="40,0,48,0">
+        <var name="level" id="2082074084068639040" />
+        <var name="msg" id="3679134236456135421" />
+      </scope>
+      <scope id="3679134236455947784" at="23,127,37,5" />
+      <scope id="3679134236455947780" at="23,0,39,0">
         <var name="exception" id="3679134236455947869" />
         <var name="hint" id="2096919206294020429" />
         <var name="project" id="3679134236455947872" />
         <var name="sender" id="3679134236455947865" />
       </scope>
-      <scope id="3679134236456133573" at="27,46,33,45">
-        <var name="lr" id="6583289326083565397" />
-      </scope>
-      <scope id="3679134236456133570" at="27,0,35,0">
-        <var name="level" id="2082074084068639040" />
-        <var name="msg" id="3679134236456135421" />
-      </scope>
-      <unit id="3679134236455946004" at="12,0,61,0" name="jetbrains.mps.baseLanguage.logging.rt.LogCtx" />
+      <unit id="3679134236455946004" at="15,0,74,0" name="jetbrains.mps.baseLanguage.logging.rt.LogCtx" />
     </file>
   </root>
   <root nodeRef="r:cc7bd7ff-ad7f-43d6-97d1-d660e55b3d10(jetbrains.mps.baseLanguage.logging.rt)/3679134236456112307">
     <file name="LogContext.java">
-      <node id="3679134236455937705" at="13,110,14,67" concept="5" />
-      <node id="2096919206294057357" at="16,133,17,67" concept="5" />
-      <node id="3679134236455936295" at="13,0,16,0" concept="8" trace="with#(Ljava/lang/Class;Ljava/lang/Throwable;Lorg/jetbrains/mps/openapi/project/Project;)Ljetbrains/mps/baseLanguage/logging/rt/Log;" />
-      <node id="2096919206294057342" at="16,0,19,0" concept="8" trace="with#(Ljava/lang/Class;Ljava/lang/Throwable;Lorg/jetbrains/mps/openapi/project/Project;Ljava/lang/Object;)Ljetbrains/mps/baseLanguage/logging/rt/Log;" />
+      <node id="3679134236455937705" at="13,110,14,67" concept="7" />
+      <node id="2096919206294057357" at="16,133,17,67" concept="7" />
+      <node id="3679134236455936295" at="13,0,16,0" concept="10" trace="with#(Ljava/lang/Class;Ljava/lang/Throwable;Lorg/jetbrains/mps/openapi/project/Project;)Ljetbrains/mps/baseLanguage/logging/rt/Log;" />
+      <node id="2096919206294057342" at="16,0,19,0" concept="10" trace="with#(Ljava/lang/Class;Ljava/lang/Throwable;Lorg/jetbrains/mps/openapi/project/Project;Ljava/lang/Object;)Ljetbrains/mps/baseLanguage/logging/rt/Log;" />
       <scope id="3679134236455936298" at="13,110,14,67" />
       <scope id="2096919206294057356" at="16,133,17,67" />
       <scope id="3679134236455936295" at="13,0,16,0">

--- a/languages/baseLanguage/logging/runtime/source_gen/jetbrains/mps/baseLanguage/logging/rt/trace.info
+++ b/languages/baseLanguage/logging/runtime/source_gen/jetbrains/mps/baseLanguage/logging/rt/trace.info
@@ -1,10 +1,8 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <debug-info version="2">
-  <concept fqn="c:f3061a53-9226-4cc5-a443-f952ceaf5816/1082485599095:jetbrains.mps.baseLanguage.structure.BlockStatement" />
   <concept fqn="c:f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123140:jetbrains.mps.baseLanguage.structure.ConstructorDeclaration" />
   <concept fqn="c:f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123155:jetbrains.mps.baseLanguage.structure.ExpressionStatement" />
   <concept fqn="c:f3061a53-9226-4cc5-a443-f952ceaf5816/1068390468200:jetbrains.mps.baseLanguage.structure.FieldDeclaration" />
-  <concept fqn="c:f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123159:jetbrains.mps.baseLanguage.structure.IfStatement" />
   <concept fqn="c:f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123165:jetbrains.mps.baseLanguage.structure.InstanceMethodDeclaration" />
   <concept fqn="c:f3061a53-9226-4cc5-a443-f952ceaf5816/1068581242864:jetbrains.mps.baseLanguage.structure.LocalVariableDeclarationStatement" />
   <concept fqn="c:f3061a53-9226-4cc5-a443-f952ceaf5816/1068581242878:jetbrains.mps.baseLanguage.structure.ReturnStatement" />
@@ -13,12 +11,12 @@
   <concept fqn="c:f3061a53-9226-4cc5-a443-f952ceaf5816/1081236700938:jetbrains.mps.baseLanguage.structure.StaticMethodDeclaration" />
   <root nodeRef="r:cc7bd7ff-ad7f-43d6-97d1-d660e55b3d10(jetbrains.mps.baseLanguage.logging.rt)/3679134236455929071">
     <file name="Log.java">
-      <node id="3679134236455932153" at="10,0,11,0" concept="5" trace="fatal#(Ljava/lang/Object;)V" />
-      <node id="3679134236455932668" at="11,0,12,0" concept="5" trace="error#(Ljava/lang/Object;)V" />
-      <node id="3679134236455933114" at="12,0,13,0" concept="5" trace="warning#(Ljava/lang/Object;)V" />
-      <node id="3679134236455933420" at="13,0,14,0" concept="5" trace="info#(Ljava/lang/Object;)V" />
-      <node id="3679134236455933812" at="14,0,15,0" concept="5" trace="debug#(Ljava/lang/Object;)V" />
-      <node id="3679134236455934290" at="15,0,16,0" concept="5" trace="trace#(Ljava/lang/Object;)V" />
+      <node id="3679134236455932153" at="10,0,11,0" concept="3" trace="fatal#(Ljava/lang/Object;)V" />
+      <node id="3679134236455932668" at="11,0,12,0" concept="3" trace="error#(Ljava/lang/Object;)V" />
+      <node id="3679134236455933114" at="12,0,13,0" concept="3" trace="warning#(Ljava/lang/Object;)V" />
+      <node id="3679134236455933420" at="13,0,14,0" concept="3" trace="info#(Ljava/lang/Object;)V" />
+      <node id="3679134236455933812" at="14,0,15,0" concept="3" trace="debug#(Ljava/lang/Object;)V" />
+      <node id="3679134236455934290" at="15,0,16,0" concept="3" trace="trace#(Ljava/lang/Object;)V" />
       <scope id="3679134236455932153" at="10,0,11,0">
         <var name="msg" id="3679134236455932214" />
       </scope>
@@ -42,89 +40,96 @@
   </root>
   <root nodeRef="r:cc7bd7ff-ad7f-43d6-97d1-d660e55b3d10(jetbrains.mps.baseLanguage.logging.rt)/3679134236455946004">
     <file name="LogCtx.java">
-      <node id="5721587534047579222" at="13,0,14,0" concept="9" trace="MSG_VIEW_TOKEN" />
-      <node id="3679134236455948671" at="15,0,16,0" concept="3" trace="mySender" />
-      <node id="3679134236455949116" at="16,0,17,0" concept="3" trace="myException" />
-      <node id="3679134236455949364" at="17,0,18,0" concept="3" trace="myProject" />
-      <node id="3679134236455948675" at="19,104,20,22" concept="2" />
-      <node id="3679134236455949120" at="20,22,21,28" concept="2" />
-      <node id="3679134236455949368" at="21,28,22,24" concept="2" />
-      <node id="6583289326083632563" at="25,46,26,101" concept="8" />
-      <node id="6583289326083635098" at="26,101,27,30" concept="8" />
-      <node id="6583289326083565396" at="27,30,28,61" concept="6" />
-      <node id="6583289326083582190" at="28,61,29,30" concept="2" />
-      <node id="6583289326083606516" at="30,28,31,47" concept="2" />
-      <node id="6583289326083624679" at="32,12,33,58" concept="2" />
-      <node id="3679134236456145564" at="34,5,35,45" concept="2" />
-      <node id="3679134236456170790" at="39,33,40,28" concept="2" />
-      <node id="3679134236456176023" at="43,33,44,28" concept="2" />
-      <node id="3679134236456178250" at="47,35,48,29" concept="2" />
-      <node id="3679134236456178994" at="51,32,52,26" concept="2" />
-      <node id="3679134236456180264" at="55,33,56,26" concept="2" />
-      <node id="3679134236456181090" at="59,33,60,28" concept="2" />
-      <node id="6583289326083623727" at="32,10,34,5" concept="0" />
-      <node id="3679134236455950050" at="38,0,42,0" concept="5" trace="fatal#(Ljava/lang/Object;)V" />
-      <node id="3679134236455950058" at="42,0,46,0" concept="5" trace="error#(Ljava/lang/Object;)V" />
-      <node id="3679134236455950066" at="46,0,50,0" concept="5" trace="warning#(Ljava/lang/Object;)V" />
-      <node id="3679134236455950074" at="50,0,54,0" concept="5" trace="info#(Ljava/lang/Object;)V" />
-      <node id="3679134236455950082" at="54,0,58,0" concept="5" trace="debug#(Ljava/lang/Object;)V" />
-      <node id="3679134236455950090" at="58,0,62,0" concept="5" trace="trace#(Ljava/lang/Object;)V" />
-      <node id="3679134236455947780" at="19,0,24,0" concept="1" trace="LogCtx#(Ljava/lang/String;Ljava/lang/Throwable;Lorg/jetbrains/mps/openapi/project/Project;)V" />
-      <node id="6583289326083611235" at="29,30,34,5" concept="4" />
-      <node id="3679134236456133570" at="25,0,37,0" concept="5" trace="_log#(Ljava/util/logging/Level;Ljava/lang/Object;)V" />
-      <scope id="6583289326083611237" at="30,28,31,47" />
-      <scope id="6583289326083623728" at="32,12,33,58" />
-      <scope id="3679134236455950056" at="39,33,40,28" />
-      <scope id="3679134236455950064" at="43,33,44,28" />
-      <scope id="3679134236455950072" at="47,35,48,29" />
-      <scope id="3679134236455950080" at="51,32,52,26" />
-      <scope id="3679134236455950088" at="55,33,56,26" />
-      <scope id="3679134236455950096" at="59,33,60,28" />
-      <scope id="3679134236455947784" at="19,104,22,24" />
-      <scope id="3679134236455950050" at="38,0,42,0">
+      <node id="5721587534047579222" at="13,0,14,0" concept="7" trace="MSG_VIEW_TOKEN" />
+      <node id="3679134236455948671" at="15,0,16,0" concept="2" trace="mySender" />
+      <node id="3679134236455949116" at="16,0,17,0" concept="2" trace="myException" />
+      <node id="3679134236455949364" at="17,0,18,0" concept="2" trace="myProject" />
+      <node id="2096919206294022870" at="18,0,19,0" concept="2" trace="myHint" />
+      <node id="3679134236455948675" at="20,127,21,22" concept="1" />
+      <node id="3679134236455949120" at="21,22,22,28" concept="1" />
+      <node id="3679134236455949368" at="22,28,23,24" concept="1" />
+      <node id="2096919206294022874" at="23,24,24,18" concept="1" />
+      <node id="6583289326083632563" at="27,46,28,101" concept="6" />
+      <node id="6583289326083635098" at="28,101,29,30" concept="6" />
+      <node id="6583289326083565396" at="29,30,30,61" concept="4" />
+      <node id="6583289326083582190" at="30,61,31,30" concept="1" />
+      <node id="2096919206294032572" at="31,30,32,64" concept="1" />
+      <node id="3679134236456145564" at="32,64,33,45" concept="1" />
+      <node id="3679134236456170790" at="37,33,38,28" concept="1" />
+      <node id="3679134236456176023" at="41,33,42,28" concept="1" />
+      <node id="3679134236456178250" at="45,35,46,29" concept="1" />
+      <node id="3679134236456178994" at="49,32,50,26" concept="1" />
+      <node id="3679134236456180264" at="53,33,54,26" concept="1" />
+      <node id="3679134236456181090" at="57,33,58,28" concept="1" />
+      <node id="3679134236455950050" at="36,0,40,0" concept="3" trace="fatal#(Ljava/lang/Object;)V" />
+      <node id="3679134236455950058" at="40,0,44,0" concept="3" trace="error#(Ljava/lang/Object;)V" />
+      <node id="3679134236455950066" at="44,0,48,0" concept="3" trace="warning#(Ljava/lang/Object;)V" />
+      <node id="3679134236455950074" at="48,0,52,0" concept="3" trace="info#(Ljava/lang/Object;)V" />
+      <node id="3679134236455950082" at="52,0,56,0" concept="3" trace="debug#(Ljava/lang/Object;)V" />
+      <node id="3679134236455950090" at="56,0,60,0" concept="3" trace="trace#(Ljava/lang/Object;)V" />
+      <node id="3679134236455947780" at="20,0,26,0" concept="0" trace="LogCtx#(Ljava/lang/String;Ljava/lang/Throwable;Lorg/jetbrains/mps/openapi/project/Project;Ljava/lang/Object;)V" />
+      <node id="3679134236456133570" at="27,0,35,0" concept="3" trace="_log#(Ljava/util/logging/Level;Ljava/lang/Object;)V" />
+      <scope id="3679134236455950056" at="37,33,38,28" />
+      <scope id="3679134236455950064" at="41,33,42,28" />
+      <scope id="3679134236455950072" at="45,35,46,29" />
+      <scope id="3679134236455950080" at="49,32,50,26" />
+      <scope id="3679134236455950088" at="53,33,54,26" />
+      <scope id="3679134236455950096" at="57,33,58,28" />
+      <scope id="3679134236455947784" at="20,127,24,18" />
+      <scope id="3679134236455950050" at="36,0,40,0">
         <var name="msg" id="3679134236455950054" />
       </scope>
-      <scope id="3679134236455950058" at="42,0,46,0">
+      <scope id="3679134236455950058" at="40,0,44,0">
         <var name="msg" id="3679134236455950059" />
       </scope>
-      <scope id="3679134236455950066" at="46,0,50,0">
+      <scope id="3679134236455950066" at="44,0,48,0">
         <var name="msg" id="3679134236455950067" />
       </scope>
-      <scope id="3679134236455950074" at="50,0,54,0">
+      <scope id="3679134236455950074" at="48,0,52,0">
         <var name="msg" id="3679134236455950075" />
       </scope>
-      <scope id="3679134236455950082" at="54,0,58,0">
+      <scope id="3679134236455950082" at="52,0,56,0">
         <var name="msg" id="3679134236455950083" />
       </scope>
-      <scope id="3679134236455950090" at="58,0,62,0">
+      <scope id="3679134236455950090" at="56,0,60,0">
         <var name="msg" id="3679134236455950091" />
       </scope>
-      <scope id="3679134236455947780" at="19,0,24,0">
+      <scope id="3679134236455947780" at="20,0,26,0">
         <var name="exception" id="3679134236455947869" />
+        <var name="hint" id="2096919206294020429" />
         <var name="project" id="3679134236455947872" />
         <var name="sender" id="3679134236455947865" />
       </scope>
-      <scope id="3679134236456133573" at="25,46,35,45">
+      <scope id="3679134236456133573" at="27,46,33,45">
         <var name="lr" id="6583289326083565397" />
       </scope>
-      <scope id="3679134236456133570" at="25,0,37,0">
+      <scope id="3679134236456133570" at="27,0,35,0">
         <var name="level" id="2082074084068639040" />
         <var name="msg" id="3679134236456135421" />
       </scope>
-      <unit id="3679134236455946004" at="12,0,63,0" name="jetbrains.mps.baseLanguage.logging.rt.LogCtx" />
+      <unit id="3679134236455946004" at="12,0,61,0" name="jetbrains.mps.baseLanguage.logging.rt.LogCtx" />
     </file>
   </root>
   <root nodeRef="r:cc7bd7ff-ad7f-43d6-97d1-d660e55b3d10(jetbrains.mps.baseLanguage.logging.rt)/3679134236456112307">
     <file name="LogContext.java">
-      <node id="3679134236455937705" at="13,110,14,61" concept="7" />
-      <node id="3679134236455936295" at="13,0,16,0" concept="10" trace="with#(Ljava/lang/Class;Ljava/lang/Throwable;Lorg/jetbrains/mps/openapi/project/Project;)Ljetbrains/mps/baseLanguage/logging/rt/Log;" />
-      <scope id="3679134236455936298" at="13,110,14,61" />
+      <node id="3679134236455937705" at="13,110,14,67" concept="5" />
+      <node id="2096919206294057357" at="16,133,17,67" concept="5" />
+      <node id="3679134236455936295" at="13,0,16,0" concept="8" trace="with#(Ljava/lang/Class;Ljava/lang/Throwable;Lorg/jetbrains/mps/openapi/project/Project;)Ljetbrains/mps/baseLanguage/logging/rt/Log;" />
+      <node id="2096919206294057342" at="16,0,19,0" concept="8" trace="with#(Ljava/lang/Class;Ljava/lang/Throwable;Lorg/jetbrains/mps/openapi/project/Project;Ljava/lang/Object;)Ljetbrains/mps/baseLanguage/logging/rt/Log;" />
+      <scope id="3679134236455936298" at="13,110,14,67" />
+      <scope id="2096919206294057356" at="16,133,17,67" />
       <scope id="3679134236455936295" at="13,0,16,0">
         <var name="project" id="3679134236455937177" />
         <var name="sender" id="3679134236455937170" />
         <var name="throwable" id="3679134236455937174" />
       </scope>
-      <unit id="3679134236456112307" at="12,0,17,0" name="jetbrains.mps.baseLanguage.logging.rt.LogContext" />
+      <scope id="2096919206294057342" at="16,0,19,0">
+        <var name="hint" id="2096919206294057353" />
+        <var name="project" id="2096919206294057350" />
+        <var name="sender" id="2096919206294057343" />
+        <var name="throwable" id="2096919206294057347" />
+      </scope>
+      <unit id="3679134236456112307" at="12,0,20,0" name="jetbrains.mps.baseLanguage.logging.rt.LogContext" />
     </file>
   </root>
 </debug-info>

--- a/languages/baseLanguage/logging/source_gen.caches/jetbrains/mps/baseLanguage/logging/actions/generated
+++ b/languages/baseLanguage/logging/source_gen.caches/jetbrains/mps/baseLanguage/logging/actions/generated
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<product version="3" modelHash="-cca65rxuksg8wbj4ls95hb2irt0s1x2">
+<product version="3" modelHash="-94npsnqqvfxultoxbxukfm1drnu6g4y">
   <files names="ActionAspectDescriptorImpl.java:LogStatementConversions.java" />
 </product>
 

--- a/languages/baseLanguage/logging/source_gen.caches/jetbrains/mps/baseLanguage/logging/editor/generated
+++ b/languages/baseLanguage/logging/source_gen.caches/jetbrains/mps/baseLanguage/logging/editor/generated
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<product version="3" modelHash="7vl2xr64anh1rwf9k72as64w16m4fmg">
+<product version="3" modelHash="-bt7mhy5edo1rqp64iib571j6suih9qu">
   <files names="EditorAspectDescriptorImpl.java:LogLowFirstCell.java:LogLowLevelStatement_Editor.java:LogLowLevelStatement_EditorBuilder_a.java:LogLowLevelStatement_SubstituteMenu.java:MsgFirstCell.java:MsgStatement_Editor.java:MsgStatement_EditorBuilder_a.java:MsgStatement_SubstituteMenu.java:PrintStatement_Editor.java:PrintStatement_EditorBuilder_a.java:ReplaceLogWithMessage.java:ReplaceMessageWithLog.java:loggingLowLevel_nodeSubstitute_Contribution.java:loggingMsg_nodeSubstitute_Contribution.java" />
 </product>
 

--- a/languages/baseLanguage/logging/source_gen.caches/jetbrains/mps/baseLanguage/logging/generated
+++ b/languages/baseLanguage/logging/source_gen.caches/jetbrains/mps/baseLanguage/logging/generated
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<product version="3" modelHash="-2irkvqga99615ymd5ukoammtql2gwef">
+<product version="3" modelHash="-3p8ltd05rcvtcc75e08cdp4eptafnvk">
   <files names="Language.java" />
 </product>
 

--- a/languages/baseLanguage/logging/source_gen.caches/jetbrains/mps/baseLanguage/logging/structure/generated
+++ b/languages/baseLanguage/logging/source_gen.caches/jetbrains/mps/baseLanguage/logging/structure/generated
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<product version="3" modelHash="55sd8w62or5lkf8w42l3zf8ttfusw23">
+<product version="3" modelHash="-4nt0svjxbc599mibyx60q8ggv5stujg">
   <files names="ConceptPresentationAspectImpl.java:EnumerationDescriptor_Severity.java:LanguageConceptSwitch.java:StructureAspectDescriptor.java" />
 </product>
 

--- a/languages/baseLanguage/logging/source_gen/jetbrains/mps/baseLanguage/logging/actions/LogStatementConversions.java
+++ b/languages/baseLanguage/logging/source_gen/jetbrains/mps/baseLanguage/logging/actions/LogStatementConversions.java
@@ -42,6 +42,7 @@ public class LogStatementConversions {
           SLinkOperations.setTarget(newNode, LINKS.message$I3Bb, SLinkOperations.getTarget(msg, LINKS.message$I3Bb));
           SPropertyOperations.assignEnum(newNode, PROPS.severity$lcf9, SPropertyOperations.getEnum(msg, PROPS.severity$lcf9));
           SLinkOperations.setTarget(newNode, LINKS.throwable$I3Qc, SLinkOperations.getTarget(msg, LINKS.throwable$I3Qc));
+          SLinkOperations.setTarget(newNode, LINKS.hint$bvDr, SLinkOperations.getTarget(msg, LINKS.hint$bvDr));
         }
       }
       {
@@ -65,6 +66,7 @@ public class LogStatementConversions {
     /*package*/ static final SContainmentLink message$I3Bb = MetaAdapterFactory.getContainmentLink(0x760a0a8ceabb4521L, 0x8bfd65db761a9ba3L, 0x57e2cf14f6d5a71dL, 0x4f67298c4630c25eL, "message");
     /*package*/ static final SContainmentLink throwable$TgqN = MetaAdapterFactory.getContainmentLink(0x760a0a8ceabb4521L, 0x8bfd65db761a9ba3L, 0x1c3d779b2be2f0b9L, 0x1c3d779b2be2f1bbL, "throwable");
     /*package*/ static final SContainmentLink throwable$I3Qc = MetaAdapterFactory.getContainmentLink(0x760a0a8ceabb4521L, 0x8bfd65db761a9ba3L, 0x57e2cf14f6d5a71dL, 0x4f67298c4630c25fL, "throwable");
+    /*package*/ static final SContainmentLink hint$bvDr = MetaAdapterFactory.getContainmentLink(0x760a0a8ceabb4521L, 0x8bfd65db761a9ba3L, 0x57e2cf14f6d5a71dL, 0x1d19c0e87d9d67c2L, "hint");
   }
 
   private static final class PROPS {

--- a/languages/baseLanguage/logging/source_gen/jetbrains/mps/baseLanguage/logging/actions/trace.info
+++ b/languages/baseLanguage/logging/source_gen/jetbrains/mps/baseLanguage/logging/actions/trace.info
@@ -25,46 +25,48 @@
       <node id="6057591418743066496" at="41,74,42,117" concept="1" />
       <node id="6057591418743066504" at="42,117,43,126" concept="1" />
       <node id="6057591418743066512" at="43,126,44,121" concept="1" />
-      <node id="6057591418743066522" at="47,7,48,37" concept="4" />
-      <node id="6057591418743066525" at="49,82,50,117" concept="1" />
-      <node id="6057591418743066533" at="50,117,51,126" concept="1" />
-      <node id="6057591418743066541" at="51,126,52,121" concept="1" />
-      <node id="6057591418743042049" at="59,0,60,0" concept="5" trace="MsgStatement$Pu" />
-      <node id="6057591418743042049" at="60,0,61,0" concept="5" trace="LogLowLevelStatement$3g" />
-      <node id="6057591418743042049" at="64,0,65,0" concept="5" trace="message$TfWL" />
-      <node id="6057591418743042049" at="65,0,66,0" concept="5" trace="message$I3Bb" />
-      <node id="6057591418743042049" at="66,0,67,0" concept="5" trace="throwable$TgqN" />
-      <node id="6057591418743042049" at="67,0,68,0" concept="5" trace="throwable$I3Qc" />
-      <node id="6057591418743042049" at="71,0,72,0" concept="5" trace="severity$TfuJ" />
-      <node id="6057591418743042049" at="72,0,73,0" concept="5" trace="severity$lcf9" />
+      <node id="2096919206290105950" at="44,121,45,111" concept="1" />
+      <node id="6057591418743066522" at="48,7,49,37" concept="4" />
+      <node id="6057591418743066525" at="50,82,51,117" concept="1" />
+      <node id="6057591418743066533" at="51,117,52,126" concept="1" />
+      <node id="6057591418743066541" at="52,126,53,121" concept="1" />
+      <node id="6057591418743042049" at="60,0,61,0" concept="5" trace="MsgStatement$Pu" />
+      <node id="6057591418743042049" at="61,0,62,0" concept="5" trace="LogLowLevelStatement$3g" />
+      <node id="6057591418743042049" at="65,0,66,0" concept="5" trace="message$TfWL" />
+      <node id="6057591418743042049" at="66,0,67,0" concept="5" trace="message$I3Bb" />
+      <node id="6057591418743042049" at="67,0,68,0" concept="5" trace="throwable$TgqN" />
+      <node id="6057591418743042049" at="68,0,69,0" concept="5" trace="throwable$I3Qc" />
+      <node id="6057591418743042049" at="69,0,70,0" concept="5" trace="hint$bvDr" />
+      <node id="6057591418743042049" at="73,0,74,0" concept="5" trace="severity$TfuJ" />
+      <node id="6057591418743042049" at="74,0,75,0" concept="5" trace="severity$lcf9" />
       <node id="6057591418743042056" at="20,37,25,9" concept="2" />
       <node id="6057591418743065494" at="28,37,33,9" concept="2" />
-      <node id="6057591418743066493" at="40,37,45,9" concept="2" />
-      <node id="6057591418743066522" at="48,37,53,9" concept="2" />
+      <node id="6057591418743066522" at="49,37,54,9" concept="2" />
+      <node id="6057591418743066493" at="40,37,46,9" concept="2" />
       <node id="6057591418743042056" at="18,102,26,7" concept="0" />
       <node id="6057591418743065494" at="26,7,34,7" concept="0" />
-      <node id="6057591418743066493" at="38,102,46,7" concept="0" />
-      <node id="6057591418743066522" at="46,7,54,7" concept="0" />
+      <node id="6057591418743066522" at="47,7,55,7" concept="0" />
+      <node id="6057591418743066493" at="38,102,47,7" concept="0" />
       <node id="6057591418743042050" at="18,0,36,0" concept="3" trace="setup#(Lorg/jetbrains/mps/openapi/model/SNode;Lorg/jetbrains/mps/openapi/model/SNode;Lorg/jetbrains/mps/openapi/model/SNode;ILorg/jetbrains/mps/openapi/model/SModel;)V" />
-      <node id="6057591418743066490" at="38,0,56,0" concept="3" trace="setup#(Lorg/jetbrains/mps/openapi/model/SNode;Lorg/jetbrains/mps/openapi/model/SNode;Lorg/jetbrains/mps/openapi/model/SNode;ILorg/jetbrains/mps/openapi/model/SModel;)V" />
+      <node id="6057591418743066490" at="38,0,57,0" concept="3" trace="setup#(Lorg/jetbrains/mps/openapi/model/SNode;Lorg/jetbrains/mps/openapi/model/SNode;Lorg/jetbrains/mps/openapi/model/SNode;ILorg/jetbrains/mps/openapi/model/SModel;)V" />
       <scope id="6057591418743042058" at="21,74,24,121" />
       <scope id="6057591418743065496" at="29,82,32,121" />
-      <scope id="6057591418743066495" at="41,74,44,121" />
-      <scope id="6057591418743066524" at="49,82,52,121" />
+      <scope id="6057591418743066524" at="50,82,53,121" />
+      <scope id="6057591418743066495" at="41,74,45,111" />
       <scope id="6057591418743042056" at="19,7,25,9">
         <var name="msg" id="6057591418743042056" />
       </scope>
       <scope id="6057591418743065494" at="27,7,33,9">
         <var name="msg" id="6057591418743065494" />
       </scope>
-      <scope id="6057591418743066493" at="39,7,45,9">
-        <var name="msg" id="6057591418743066493" />
-      </scope>
-      <scope id="6057591418743066522" at="47,7,53,9">
+      <scope id="6057591418743066522" at="48,7,54,9">
         <var name="msg" id="6057591418743066522" />
       </scope>
+      <scope id="6057591418743066493" at="39,7,46,9">
+        <var name="msg" id="6057591418743066493" />
+      </scope>
       <scope id="6057591418743042050" at="18,102,34,7" />
-      <scope id="6057591418743066490" at="38,102,54,7" />
+      <scope id="6057591418743066490" at="38,102,55,7" />
       <scope id="6057591418743042050" at="18,0,36,0">
         <var name="enclosingNode" id="6057591418743042050" />
         <var name="index" id="6057591418743042050" />
@@ -72,19 +74,19 @@
         <var name="newNode" id="6057591418743042050" />
         <var name="sampleNode" id="6057591418743042050" />
       </scope>
-      <scope id="6057591418743066490" at="38,0,56,0">
+      <scope id="6057591418743066490" at="38,0,57,0">
         <var name="enclosingNode" id="6057591418743066490" />
         <var name="index" id="6057591418743066490" />
         <var name="model" id="6057591418743066490" />
         <var name="newNode" id="6057591418743066490" />
         <var name="sampleNode" id="6057591418743066490" />
       </scope>
-      <unit id="6057591418743042049" at="58,0,62,0" name="jetbrains.mps.baseLanguage.logging.actions.LogStatementConversions$CONCEPTS" />
-      <unit id="6057591418743042049" at="70,0,74,0" name="jetbrains.mps.baseLanguage.logging.actions.LogStatementConversions$PROPS" />
-      <unit id="6057591418743042049" at="63,0,69,0" name="jetbrains.mps.baseLanguage.logging.actions.LogStatementConversions$LINKS" />
+      <unit id="6057591418743042049" at="59,0,63,0" name="jetbrains.mps.baseLanguage.logging.actions.LogStatementConversions$CONCEPTS" />
+      <unit id="6057591418743042049" at="72,0,76,0" name="jetbrains.mps.baseLanguage.logging.actions.LogStatementConversions$PROPS" />
+      <unit id="6057591418743042049" at="64,0,71,0" name="jetbrains.mps.baseLanguage.logging.actions.LogStatementConversions$LINKS" />
       <unit id="6057591418743042050" at="17,0,37,0" name="jetbrains.mps.baseLanguage.logging.actions.LogStatementConversions$NodeFactory_6057591418743042050" />
-      <unit id="6057591418743066490" at="37,0,57,0" name="jetbrains.mps.baseLanguage.logging.actions.LogStatementConversions$NodeFactory_6057591418743066490" />
-      <unit id="6057591418743042049" at="16,0,75,0" name="jetbrains.mps.baseLanguage.logging.actions.LogStatementConversions" />
+      <unit id="6057591418743066490" at="37,0,58,0" name="jetbrains.mps.baseLanguage.logging.actions.LogStatementConversions$NodeFactory_6057591418743066490" />
+      <unit id="6057591418743042049" at="16,0,77,0" name="jetbrains.mps.baseLanguage.logging.actions.LogStatementConversions" />
     </file>
   </root>
 </debug-info>

--- a/languages/baseLanguage/logging/source_gen/jetbrains/mps/baseLanguage/logging/editor/MsgStatement_EditorBuilder_a.java
+++ b/languages/baseLanguage/logging/source_gen/jetbrains/mps/baseLanguage/logging/editor/MsgStatement_EditorBuilder_a.java
@@ -72,7 +72,8 @@ import jetbrains.mps.smodel.adapter.structure.MetaAdapterFactory;
     editorCell.addEditorCell(createRefNode_0());
     editorCell.addEditorCell(createCollection_1());
     editorCell.addEditorCell(createCollection_2());
-    editorCell.addEditorCell(createConstant_3());
+    editorCell.addEditorCell(createCollection_3());
+    editorCell.addEditorCell(createConstant_4());
     return editorCell;
   }
   private EditorCell createConstant_0() {
@@ -190,14 +191,86 @@ import jetbrains.mps.smodel.adapter.structure.MetaAdapterFactory;
     return editorCell;
   }
   private EditorCell createRefNode_1() {
-    SingleRoleCellProvider provider = new projectSingleRoleHandler_tetib3_b3a(myNode, LINKS.project$OYlE, getEditorContext());
+    SingleRoleCellProvider provider = new hintSingleRoleHandler_tetib3_b3a(myNode, LINKS.hint$bvDr, getEditorContext());
     return provider.createCell();
   }
-  private static class projectSingleRoleHandler_tetib3_b3a extends SingleRoleCellProvider {
+  private static class hintSingleRoleHandler_tetib3_b3a extends SingleRoleCellProvider {
     @NotNull
     private SNode myNode;
 
-    public projectSingleRoleHandler_tetib3_b3a(SNode ownerNode, SContainmentLink containmentLink, EditorContext context) {
+    public hintSingleRoleHandler_tetib3_b3a(SNode ownerNode, SContainmentLink containmentLink, EditorContext context) {
+      super(containmentLink, context);
+      myNode = ownerNode;
+    }
+
+    @Override
+    @NotNull
+    public SNode getNode() {
+      return myNode;
+    }
+
+    protected EditorCell createChildCell(SNode child) {
+      EditorCell editorCell = getUpdateSession().updateChildNodeCell(child);
+      editorCell.setAction(CellActionType.DELETE, new CellAction_DeleteSmart(getNode(), LINKS.hint$bvDr, child));
+      editorCell.setAction(CellActionType.BACKSPACE, new CellAction_DeleteSmart(getNode(), LINKS.hint$bvDr, child));
+      installCellInfo(child, editorCell, false);
+      return editorCell;
+    }
+
+
+
+    private void installCellInfo(SNode child, EditorCell editorCell, boolean isEmpty) {
+      if (editorCell.getSubstituteInfo() == null || editorCell.getSubstituteInfo() instanceof DefaultSubstituteInfo) {
+        editorCell.setSubstituteInfo((isEmpty ? new SEmptyContainmentSubstituteInfo(editorCell) : new SChildSubstituteInfo(editorCell)));
+      }
+      if (editorCell.getSRole() == null) {
+        editorCell.setSRole(LINKS.hint$bvDr);
+      }
+    }
+    @Override
+    protected EditorCell createEmptyCell() {
+      getCellFactory().pushCellContext();
+      getCellFactory().setNodeLocation(new SNodeLocation.FromParentAndLink(getNode(), LINKS.hint$bvDr));
+      try {
+        EditorCell editorCell = super.createEmptyCell();
+        editorCell.setCellId("empty_hint");
+        installCellInfo(null, editorCell, true);
+        setCellContext(editorCell);
+        return editorCell;
+      } finally {
+        getCellFactory().popCellContext();
+      }
+    }
+    protected String getNoTargetText() {
+      return "<no hint>";
+    }
+  }
+  private EditorCell createCollection_2() {
+    EditorCell_Collection editorCell = new EditorCell_Collection(getEditorContext(), myNode, new CellLayout_Indent());
+    editorCell.setCellId("Collection_tetib3_e0");
+    editorCell.addEditorCell(createConstant_2());
+    editorCell.addEditorCell(createRefNode_2());
+    return editorCell;
+  }
+  private EditorCell createConstant_2() {
+    EditorCell_Constant editorCell = new EditorCell_Constant(getEditorContext(), myNode, ",");
+    editorCell.setCellId("Constant_tetib3_a4a");
+    Style style = new StyleImpl();
+    style.set(StyleAttributes.SELECTABLE, false);
+    style.set(StyleAttributes.PUNCTUATION_LEFT, true);
+    editorCell.getStyle().putAll(style);
+    editorCell.setDefaultText("");
+    return editorCell;
+  }
+  private EditorCell createRefNode_2() {
+    SingleRoleCellProvider provider = new projectSingleRoleHandler_tetib3_b4a(myNode, LINKS.project$OYlE, getEditorContext());
+    return provider.createCell();
+  }
+  private static class projectSingleRoleHandler_tetib3_b4a extends SingleRoleCellProvider {
+    @NotNull
+    private SNode myNode;
+
+    public projectSingleRoleHandler_tetib3_b4a(SNode ownerNode, SContainmentLink containmentLink, EditorContext context) {
       super(containmentLink, context);
       myNode = ownerNode;
     }
@@ -244,19 +317,19 @@ import jetbrains.mps.smodel.adapter.structure.MetaAdapterFactory;
       return "<no project>";
     }
   }
-  private EditorCell createCollection_2() {
+  private EditorCell createCollection_3() {
     EditorCell_Collection editorCell = new EditorCell_Collection(getEditorContext(), myNode, new CellLayout_Indent());
-    editorCell.setCellId("Collection_tetib3_e0");
+    editorCell.setCellId("Collection_tetib3_f0");
     Style style = new StyleImpl();
     style.set(StyleAttributes.SELECTABLE, false);
     editorCell.getStyle().putAll(style);
-    editorCell.addEditorCell(createConstant_2());
-    editorCell.addEditorCell(createRefNode_2());
+    editorCell.addEditorCell(createConstant_3());
+    editorCell.addEditorCell(createRefNode_3());
     return editorCell;
   }
-  private EditorCell createConstant_2() {
+  private EditorCell createConstant_3() {
     EditorCell_Constant editorCell = new EditorCell_Constant(getEditorContext(), myNode, ",");
-    editorCell.setCellId("Constant_tetib3_a4a");
+    editorCell.setCellId("Constant_tetib3_a5a");
     Style style = new StyleImpl();
     style.set(StyleAttributes.SELECTABLE, false);
     style.set(StyleAttributes.PUNCTUATION_LEFT, true);
@@ -264,15 +337,15 @@ import jetbrains.mps.smodel.adapter.structure.MetaAdapterFactory;
     editorCell.setDefaultText("");
     return editorCell;
   }
-  private EditorCell createRefNode_2() {
-    SingleRoleCellProvider provider = new throwableSingleRoleHandler_tetib3_b4a(myNode, LINKS.throwable$I3Qc, getEditorContext());
+  private EditorCell createRefNode_3() {
+    SingleRoleCellProvider provider = new throwableSingleRoleHandler_tetib3_b5a(myNode, LINKS.throwable$I3Qc, getEditorContext());
     return provider.createCell();
   }
-  private static class throwableSingleRoleHandler_tetib3_b4a extends SingleRoleCellProvider {
+  private static class throwableSingleRoleHandler_tetib3_b5a extends SingleRoleCellProvider {
     @NotNull
     private SNode myNode;
 
-    public throwableSingleRoleHandler_tetib3_b4a(SNode ownerNode, SContainmentLink containmentLink, EditorContext context) {
+    public throwableSingleRoleHandler_tetib3_b5a(SNode ownerNode, SContainmentLink containmentLink, EditorContext context) {
       super(containmentLink, context);
       myNode = ownerNode;
     }
@@ -319,9 +392,9 @@ import jetbrains.mps.smodel.adapter.structure.MetaAdapterFactory;
       return "<no throwable>";
     }
   }
-  private EditorCell createConstant_3() {
+  private EditorCell createConstant_4() {
     EditorCell_Constant editorCell = new EditorCell_Constant(getEditorContext(), myNode, ";");
-    editorCell.setCellId("Constant_tetib3_f0");
+    editorCell.setCellId("Constant_tetib3_g0");
     Style style = new StyleImpl();
     new SemicolonStyleClass(getEditorContext(), getNode()).apply(style, editorCell);
     editorCell.getStyle().putAll(style);
@@ -340,6 +413,7 @@ import jetbrains.mps.smodel.adapter.structure.MetaAdapterFactory;
 
   private static final class LINKS {
     /*package*/ static final SContainmentLink message$I3Bb = MetaAdapterFactory.getContainmentLink(0x760a0a8ceabb4521L, 0x8bfd65db761a9ba3L, 0x57e2cf14f6d5a71dL, 0x4f67298c4630c25eL, "message");
+    /*package*/ static final SContainmentLink hint$bvDr = MetaAdapterFactory.getContainmentLink(0x760a0a8ceabb4521L, 0x8bfd65db761a9ba3L, 0x57e2cf14f6d5a71dL, 0x1d19c0e87d9d67c2L, "hint");
     /*package*/ static final SContainmentLink project$OYlE = MetaAdapterFactory.getContainmentLink(0x760a0a8ceabb4521L, 0x8bfd65db761a9ba3L, 0x57e2cf14f6d5a71dL, 0x4f67298c4630c318L, "project");
     /*package*/ static final SContainmentLink throwable$I3Qc = MetaAdapterFactory.getContainmentLink(0x760a0a8ceabb4521L, 0x8bfd65db761a9ba3L, 0x57e2cf14f6d5a71dL, 0x4f67298c4630c25fL, "throwable");
   }

--- a/languages/baseLanguage/logging/source_gen/jetbrains/mps/baseLanguage/logging/editor/trace.info
+++ b/languages/baseLanguage/logging/source_gen/jetbrains/mps/baseLanguage/logging/editor/trace.info
@@ -1201,361 +1201,454 @@
       <node id="6332851714983843202" at="70,49,71,49" concept="1" />
       <node id="6332851714983843205" at="71,49,72,48" concept="1" />
       <node id="6332851714983843206" at="72,48,73,51" concept="1" />
-      <node id="6332851714983843212" at="73,51,74,51" concept="1" />
-      <node id="6332851714983843225" at="74,51,75,49" concept="1" />
-      <node id="6332851714983843199" at="75,49,76,22" concept="6" />
-      <node id="5721587534047314498" at="78,41,79,100" concept="5" />
-      <node id="5721587534047314498" at="79,100,80,47" concept="1" />
-      <node id="5721587534047314498" at="80,47,81,34" concept="5" />
-      <node id="5721587534047314519" at="81,34,82,57" concept="1" />
-      <node id="5721587534047314520" at="82,57,83,110" concept="1" />
-      <node id="6057591418743196880" at="83,110,84,46" concept="1" />
-      <node id="5721587534047314498" at="84,46,85,40" concept="1" />
-      <node id="5721587534047314498" at="85,40,86,228" concept="1" />
-      <node id="5721587534047314498" at="86,228,87,34" concept="1" />
-      <node id="5721587534047314498" at="87,34,88,71" concept="1" />
-      <node id="5721587534047314498" at="88,71,89,22" concept="6" />
-      <node id="6332851714983843202" at="91,41,92,39" concept="1" />
-      <node id="6332851714983843202" at="93,9,94,53" concept="5" />
-      <node id="6332851714983843202" at="94,53,95,76" concept="1" />
-      <node id="6332851714983843202" at="95,76,96,149" concept="5" />
-      <node id="6332851714983843202" at="96,149,97,49" concept="1" />
-      <node id="6332851714983843202" at="97,49,98,48" concept="1" />
-      <node id="6332851714983843202" at="98,48,99,36" concept="5" />
-      <node id="6332851714983843203" at="99,36,100,59" concept="1" />
-      <node id="6332851714983843204" at="100,59,101,112" concept="1" />
-      <node id="6332851714983843202" at="101,112,102,42" concept="1" />
-      <node id="6332851714983843202" at="102,42,103,86" concept="1" />
-      <node id="6332851714983843202" at="103,86,104,33" concept="1" />
-      <node id="6332851714983843202" at="104,33,105,155" concept="5" />
-      <node id="6332851714983843202" at="107,41,108,118" concept="6" />
-      <node id="6332851714983843202" at="111,74,112,89" concept="5" />
-      <node id="6332851714983843202" at="112,89,113,145" concept="6" />
-      <node id="6332851714983843202" at="114,12,115,24" concept="6" />
-      <node id="6332851714983843202" at="116,15,117,40" concept="1" />
-      <node id="6332851714983843199" at="120,40,121,125" concept="5" />
-      <node id="6332851714983843199" at="121,125,122,33" concept="6" />
-      <node id="6332851714983843199" at="128,121,129,38" concept="9" />
-      <node id="6332851714983843199" at="129,38,130,25" concept="1" />
-      <node id="6332851714983843199" at="135,28,136,20" concept="6" />
-      <node id="6332851714983843199" at="139,55,140,76" concept="5" />
-      <node id="6332851714983843199" at="140,76,141,116" concept="1" />
-      <node id="6332851714983843199" at="141,116,142,119" concept="1" />
-      <node id="6332851714983843199" at="142,119,143,48" concept="1" />
-      <node id="6332851714983843199" at="143,48,144,24" concept="6" />
-      <node id="6332851714983843199" at="150,118,151,137" concept="1" />
-      <node id="6332851714983843199" at="153,42,154,48" concept="1" />
-      <node id="6332851714983843199" at="158,44,159,41" concept="1" />
-      <node id="6332851714983843199" at="159,41,160,107" concept="1" />
-      <node id="6332851714983843199" at="161,11,162,56" concept="5" />
-      <node id="6332851714983843199" at="162,56,163,46" concept="1" />
-      <node id="6332851714983843199" at="163,46,164,48" concept="1" />
-      <node id="6332851714983843199" at="164,48,165,35" concept="1" />
-      <node id="6332851714983843199" at="165,35,166,26" concept="6" />
-      <node id="6332851714983843199" at="167,17,168,42" concept="1" />
-      <node id="6332851714983843199" at="171,40,172,28" concept="6" />
-      <node id="6332851714983843199" at="175,43,176,118" concept="5" />
-      <node id="6332851714983843199" at="176,118,177,49" concept="1" />
-      <node id="6332851714983843207" at="177,49,178,49" concept="1" />
-      <node id="6332851714983843210" at="178,49,179,48" concept="1" />
-      <node id="6332851714983843199" at="179,48,180,22" concept="6" />
-      <node id="6332851714983843207" at="182,41,183,94" concept="5" />
-      <node id="6332851714983843207" at="183,94,184,48" concept="1" />
-      <node id="6332851714983843207" at="184,48,185,34" concept="5" />
-      <node id="6332851714983843208" at="185,34,186,49" concept="1" />
-      <node id="6332851714983843209" at="186,49,187,54" concept="1" />
-      <node id="6332851714983843207" at="187,54,188,40" concept="1" />
-      <node id="6332851714983843207" at="188,40,189,34" concept="1" />
-      <node id="6332851714983843207" at="189,34,190,22" concept="6" />
-      <node id="6332851714983843199" at="192,40,193,126" concept="5" />
-      <node id="6332851714983843199" at="193,126,194,33" concept="6" />
-      <node id="6332851714983843199" at="200,122,201,38" concept="9" />
-      <node id="6332851714983843199" at="201,38,202,25" concept="1" />
-      <node id="6332851714983843199" at="207,28,208,20" concept="6" />
-      <node id="6332851714983843199" at="211,55,212,76" concept="5" />
-      <node id="6332851714983843199" at="212,76,213,116" concept="1" />
-      <node id="6332851714983843199" at="213,116,214,119" concept="1" />
-      <node id="6332851714983843199" at="214,119,215,48" concept="1" />
-      <node id="6332851714983843199" at="215,48,216,24" concept="6" />
-      <node id="6332851714983843199" at="222,118,223,137" concept="1" />
-      <node id="6332851714983843199" at="225,42,226,48" concept="1" />
-      <node id="6332851714983843199" at="230,44,231,41" concept="1" />
-      <node id="6332851714983843199" at="231,41,232,107" concept="1" />
-      <node id="6332851714983843199" at="233,11,234,56" concept="5" />
-      <node id="6332851714983843199" at="234,56,235,46" concept="1" />
-      <node id="6332851714983843199" at="235,46,236,48" concept="1" />
-      <node id="6332851714983843199" at="236,48,237,35" concept="1" />
-      <node id="6332851714983843199" at="237,35,238,26" concept="6" />
-      <node id="6332851714983843199" at="239,17,240,42" concept="1" />
-      <node id="6332851714983843199" at="243,40,244,28" concept="6" />
-      <node id="6332851714983843199" at="247,43,248,118" concept="5" />
-      <node id="6332851714983843199" at="248,118,249,49" concept="1" />
-      <node id="6332851714983843199" at="249,49,250,34" concept="5" />
-      <node id="6332851714983843219" at="250,34,251,49" concept="1" />
-      <node id="6332851714983843199" at="251,49,252,40" concept="1" />
-      <node id="6332851714983843220" at="252,40,253,49" concept="1" />
-      <node id="6332851714983843223" at="253,49,254,48" concept="1" />
-      <node id="6332851714983843199" at="254,48,255,22" concept="6" />
-      <node id="6332851714983843220" at="257,41,258,94" concept="5" />
-      <node id="6332851714983843220" at="258,94,259,48" concept="1" />
-      <node id="6332851714983843220" at="259,48,260,34" concept="5" />
-      <node id="6332851714983843221" at="260,34,261,49" concept="1" />
-      <node id="6332851714983843222" at="261,49,262,54" concept="1" />
-      <node id="6332851714983843220" at="262,54,263,40" concept="1" />
-      <node id="6332851714983843220" at="263,40,264,34" concept="1" />
-      <node id="6332851714983843220" at="264,34,265,22" concept="6" />
-      <node id="6332851714983843199" at="267,40,268,130" concept="5" />
-      <node id="6332851714983843199" at="268,130,269,33" concept="6" />
-      <node id="6332851714983843199" at="275,124,276,38" concept="9" />
-      <node id="6332851714983843199" at="276,38,277,25" concept="1" />
-      <node id="6332851714983843199" at="282,28,283,20" concept="6" />
-      <node id="6332851714983843199" at="286,55,287,76" concept="5" />
-      <node id="6332851714983843199" at="287,76,288,118" concept="1" />
-      <node id="6332851714983843199" at="288,118,289,121" concept="1" />
-      <node id="6332851714983843199" at="289,121,290,48" concept="1" />
-      <node id="6332851714983843199" at="290,48,291,24" concept="6" />
-      <node id="6332851714983843199" at="297,118,298,137" concept="1" />
-      <node id="6332851714983843199" at="300,42,301,50" concept="1" />
-      <node id="6332851714983843199" at="305,44,306,41" concept="1" />
-      <node id="6332851714983843199" at="306,41,307,109" concept="1" />
-      <node id="6332851714983843199" at="308,11,309,56" concept="5" />
-      <node id="6332851714983843199" at="309,56,310,48" concept="1" />
-      <node id="6332851714983843199" at="310,48,311,48" concept="1" />
-      <node id="6332851714983843199" at="311,48,312,35" concept="1" />
-      <node id="6332851714983843199" at="312,35,313,26" concept="6" />
-      <node id="6332851714983843199" at="314,17,315,42" concept="1" />
-      <node id="6332851714983843199" at="318,40,319,30" concept="6" />
-      <node id="6332851714983843225" at="322,41,323,94" concept="5" />
-      <node id="6332851714983843225" at="323,94,324,47" concept="1" />
-      <node id="6332851714983843225" at="324,47,325,34" concept="5" />
-      <node id="6332851714983843225" at="325,34,326,84" concept="1" />
-      <node id="6332851714983843225" at="326,84,327,40" concept="1" />
-      <node id="6332851714983843225" at="327,40,328,34" concept="1" />
-      <node id="6332851714983843225" at="328,34,329,22" concept="6" />
-      <node id="6332851714983843199" at="333,0,334,0" concept="8" trace="MsgStatement$Pu" />
-      <node id="6332851714983843199" at="334,0,335,0" concept="8" trace="PropertyAttribute$Gb" />
-      <node id="6332851714983843199" at="338,0,339,0" concept="8" trace="severity$lcf9" />
-      <node id="6332851714983843199" at="342,0,343,0" concept="8" trace="message$I3Bb" />
-      <node id="6332851714983843199" at="343,0,344,0" concept="8" trace="project$OYlE" />
-      <node id="6332851714983843199" at="344,0,345,0" concept="8" trace="throwable$I3Qc" />
+      <node id="2096919206290110187" at="73,51,74,51" concept="1" />
+      <node id="6332851714983843212" at="74,51,75,51" concept="1" />
+      <node id="6332851714983843225" at="75,51,76,49" concept="1" />
+      <node id="6332851714983843199" at="76,49,77,22" concept="6" />
+      <node id="5721587534047314498" at="79,41,80,100" concept="5" />
+      <node id="5721587534047314498" at="80,100,81,47" concept="1" />
+      <node id="5721587534047314498" at="81,47,82,34" concept="5" />
+      <node id="5721587534047314519" at="82,34,83,57" concept="1" />
+      <node id="5721587534047314520" at="83,57,84,110" concept="1" />
+      <node id="6057591418743196880" at="84,110,85,46" concept="1" />
+      <node id="5721587534047314498" at="85,46,86,40" concept="1" />
+      <node id="5721587534047314498" at="86,40,87,228" concept="1" />
+      <node id="5721587534047314498" at="87,228,88,34" concept="1" />
+      <node id="5721587534047314498" at="88,34,89,71" concept="1" />
+      <node id="5721587534047314498" at="89,71,90,22" concept="6" />
+      <node id="6332851714983843202" at="92,41,93,39" concept="1" />
+      <node id="6332851714983843202" at="94,9,95,53" concept="5" />
+      <node id="6332851714983843202" at="95,53,96,76" concept="1" />
+      <node id="6332851714983843202" at="96,76,97,149" concept="5" />
+      <node id="6332851714983843202" at="97,149,98,49" concept="1" />
+      <node id="6332851714983843202" at="98,49,99,48" concept="1" />
+      <node id="6332851714983843202" at="99,48,100,36" concept="5" />
+      <node id="6332851714983843203" at="100,36,101,59" concept="1" />
+      <node id="6332851714983843204" at="101,59,102,112" concept="1" />
+      <node id="6332851714983843202" at="102,112,103,42" concept="1" />
+      <node id="6332851714983843202" at="103,42,104,86" concept="1" />
+      <node id="6332851714983843202" at="104,86,105,33" concept="1" />
+      <node id="6332851714983843202" at="105,33,106,155" concept="5" />
+      <node id="6332851714983843202" at="108,41,109,118" concept="6" />
+      <node id="6332851714983843202" at="112,74,113,89" concept="5" />
+      <node id="6332851714983843202" at="113,89,114,145" concept="6" />
+      <node id="6332851714983843202" at="115,12,116,24" concept="6" />
+      <node id="6332851714983843202" at="117,15,118,40" concept="1" />
+      <node id="6332851714983843199" at="121,40,122,125" concept="5" />
+      <node id="6332851714983843199" at="122,125,123,33" concept="6" />
+      <node id="6332851714983843199" at="129,121,130,38" concept="9" />
+      <node id="6332851714983843199" at="130,38,131,25" concept="1" />
+      <node id="6332851714983843199" at="136,28,137,20" concept="6" />
+      <node id="6332851714983843199" at="140,55,141,76" concept="5" />
+      <node id="6332851714983843199" at="141,76,142,116" concept="1" />
+      <node id="6332851714983843199" at="142,116,143,119" concept="1" />
+      <node id="6332851714983843199" at="143,119,144,48" concept="1" />
+      <node id="6332851714983843199" at="144,48,145,24" concept="6" />
+      <node id="6332851714983843199" at="151,118,152,137" concept="1" />
+      <node id="6332851714983843199" at="154,42,155,48" concept="1" />
+      <node id="6332851714983843199" at="159,44,160,41" concept="1" />
+      <node id="6332851714983843199" at="160,41,161,107" concept="1" />
+      <node id="6332851714983843199" at="162,11,163,56" concept="5" />
+      <node id="6332851714983843199" at="163,56,164,46" concept="1" />
+      <node id="6332851714983843199" at="164,46,165,48" concept="1" />
+      <node id="6332851714983843199" at="165,48,166,35" concept="1" />
+      <node id="6332851714983843199" at="166,35,167,26" concept="6" />
+      <node id="6332851714983843199" at="168,17,169,42" concept="1" />
+      <node id="6332851714983843199" at="172,40,173,28" concept="6" />
+      <node id="6332851714983843199" at="176,43,177,118" concept="5" />
+      <node id="6332851714983843199" at="177,118,178,49" concept="1" />
+      <node id="6332851714983843207" at="178,49,179,49" concept="1" />
+      <node id="6332851714983843210" at="179,49,180,48" concept="1" />
+      <node id="6332851714983843199" at="180,48,181,22" concept="6" />
+      <node id="6332851714983843207" at="183,41,184,94" concept="5" />
+      <node id="6332851714983843207" at="184,94,185,48" concept="1" />
+      <node id="6332851714983843207" at="185,48,186,34" concept="5" />
+      <node id="6332851714983843208" at="186,34,187,49" concept="1" />
+      <node id="6332851714983843209" at="187,49,188,54" concept="1" />
+      <node id="6332851714983843207" at="188,54,189,40" concept="1" />
+      <node id="6332851714983843207" at="189,40,190,34" concept="1" />
+      <node id="6332851714983843207" at="190,34,191,22" concept="6" />
+      <node id="6332851714983843199" at="193,40,194,120" concept="5" />
+      <node id="6332851714983843199" at="194,120,195,33" concept="6" />
+      <node id="6332851714983843199" at="201,119,202,38" concept="9" />
+      <node id="6332851714983843199" at="202,38,203,25" concept="1" />
+      <node id="6332851714983843199" at="208,28,209,20" concept="6" />
+      <node id="6332851714983843199" at="212,55,213,76" concept="5" />
+      <node id="6332851714983843199" at="213,76,214,113" concept="1" />
+      <node id="6332851714983843199" at="214,113,215,116" concept="1" />
+      <node id="6332851714983843199" at="215,116,216,48" concept="1" />
+      <node id="6332851714983843199" at="216,48,217,24" concept="6" />
+      <node id="6332851714983843199" at="223,118,224,137" concept="1" />
+      <node id="6332851714983843199" at="226,42,227,45" concept="1" />
+      <node id="6332851714983843199" at="231,44,232,41" concept="1" />
+      <node id="6332851714983843199" at="232,41,233,104" concept="1" />
+      <node id="6332851714983843199" at="234,11,235,56" concept="5" />
+      <node id="6332851714983843199" at="235,56,236,43" concept="1" />
+      <node id="6332851714983843199" at="236,43,237,48" concept="1" />
+      <node id="6332851714983843199" at="237,48,238,35" concept="1" />
+      <node id="6332851714983843199" at="238,35,239,26" concept="6" />
+      <node id="6332851714983843199" at="240,17,241,42" concept="1" />
+      <node id="6332851714983843199" at="244,40,245,25" concept="6" />
+      <node id="6332851714983843199" at="248,43,249,118" concept="5" />
+      <node id="6332851714983843199" at="249,118,250,49" concept="1" />
+      <node id="2096919206290110188" at="250,49,251,49" concept="1" />
+      <node id="2096919206290110191" at="251,49,252,48" concept="1" />
+      <node id="6332851714983843199" at="252,48,253,22" concept="6" />
+      <node id="2096919206290110188" at="255,41,256,94" concept="5" />
+      <node id="2096919206290110188" at="256,94,257,48" concept="1" />
+      <node id="2096919206290110188" at="257,48,258,34" concept="5" />
+      <node id="2096919206290110189" at="258,34,259,49" concept="1" />
+      <node id="2096919206290110190" at="259,49,260,54" concept="1" />
+      <node id="2096919206290110188" at="260,54,261,40" concept="1" />
+      <node id="2096919206290110188" at="261,40,262,34" concept="1" />
+      <node id="2096919206290110188" at="262,34,263,22" concept="6" />
+      <node id="6332851714983843199" at="265,40,266,126" concept="5" />
+      <node id="6332851714983843199" at="266,126,267,33" concept="6" />
+      <node id="6332851714983843199" at="273,122,274,38" concept="9" />
+      <node id="6332851714983843199" at="274,38,275,25" concept="1" />
+      <node id="6332851714983843199" at="280,28,281,20" concept="6" />
+      <node id="6332851714983843199" at="284,55,285,76" concept="5" />
+      <node id="6332851714983843199" at="285,76,286,116" concept="1" />
+      <node id="6332851714983843199" at="286,116,287,119" concept="1" />
+      <node id="6332851714983843199" at="287,119,288,48" concept="1" />
+      <node id="6332851714983843199" at="288,48,289,24" concept="6" />
+      <node id="6332851714983843199" at="295,118,296,137" concept="1" />
+      <node id="6332851714983843199" at="298,42,299,48" concept="1" />
+      <node id="6332851714983843199" at="303,44,304,41" concept="1" />
+      <node id="6332851714983843199" at="304,41,305,107" concept="1" />
+      <node id="6332851714983843199" at="306,11,307,56" concept="5" />
+      <node id="6332851714983843199" at="307,56,308,46" concept="1" />
+      <node id="6332851714983843199" at="308,46,309,48" concept="1" />
+      <node id="6332851714983843199" at="309,48,310,35" concept="1" />
+      <node id="6332851714983843199" at="310,35,311,26" concept="6" />
+      <node id="6332851714983843199" at="312,17,313,42" concept="1" />
+      <node id="6332851714983843199" at="316,40,317,28" concept="6" />
+      <node id="6332851714983843199" at="320,43,321,118" concept="5" />
+      <node id="6332851714983843199" at="321,118,322,49" concept="1" />
+      <node id="6332851714983843199" at="322,49,323,34" concept="5" />
+      <node id="6332851714983843219" at="323,34,324,49" concept="1" />
+      <node id="6332851714983843199" at="324,49,325,40" concept="1" />
+      <node id="6332851714983843220" at="325,40,326,49" concept="1" />
+      <node id="6332851714983843223" at="326,49,327,48" concept="1" />
+      <node id="6332851714983843199" at="327,48,328,22" concept="6" />
+      <node id="6332851714983843220" at="330,41,331,94" concept="5" />
+      <node id="6332851714983843220" at="331,94,332,48" concept="1" />
+      <node id="6332851714983843220" at="332,48,333,34" concept="5" />
+      <node id="6332851714983843221" at="333,34,334,49" concept="1" />
+      <node id="6332851714983843222" at="334,49,335,54" concept="1" />
+      <node id="6332851714983843220" at="335,54,336,40" concept="1" />
+      <node id="6332851714983843220" at="336,40,337,34" concept="1" />
+      <node id="6332851714983843220" at="337,34,338,22" concept="6" />
+      <node id="6332851714983843199" at="340,40,341,130" concept="5" />
+      <node id="6332851714983843199" at="341,130,342,33" concept="6" />
+      <node id="6332851714983843199" at="348,124,349,38" concept="9" />
+      <node id="6332851714983843199" at="349,38,350,25" concept="1" />
+      <node id="6332851714983843199" at="355,28,356,20" concept="6" />
+      <node id="6332851714983843199" at="359,55,360,76" concept="5" />
+      <node id="6332851714983843199" at="360,76,361,118" concept="1" />
+      <node id="6332851714983843199" at="361,118,362,121" concept="1" />
+      <node id="6332851714983843199" at="362,121,363,48" concept="1" />
+      <node id="6332851714983843199" at="363,48,364,24" concept="6" />
+      <node id="6332851714983843199" at="370,118,371,137" concept="1" />
+      <node id="6332851714983843199" at="373,42,374,50" concept="1" />
+      <node id="6332851714983843199" at="378,44,379,41" concept="1" />
+      <node id="6332851714983843199" at="379,41,380,109" concept="1" />
+      <node id="6332851714983843199" at="381,11,382,56" concept="5" />
+      <node id="6332851714983843199" at="382,56,383,48" concept="1" />
+      <node id="6332851714983843199" at="383,48,384,48" concept="1" />
+      <node id="6332851714983843199" at="384,48,385,35" concept="1" />
+      <node id="6332851714983843199" at="385,35,386,26" concept="6" />
+      <node id="6332851714983843199" at="387,17,388,42" concept="1" />
+      <node id="6332851714983843199" at="391,40,392,30" concept="6" />
+      <node id="6332851714983843225" at="395,41,396,94" concept="5" />
+      <node id="6332851714983843225" at="396,94,397,47" concept="1" />
+      <node id="6332851714983843225" at="397,47,398,34" concept="5" />
+      <node id="6332851714983843225" at="398,34,399,84" concept="1" />
+      <node id="6332851714983843225" at="399,84,400,40" concept="1" />
+      <node id="6332851714983843225" at="400,40,401,34" concept="1" />
+      <node id="6332851714983843225" at="401,34,402,22" concept="6" />
+      <node id="6332851714983843199" at="406,0,407,0" concept="8" trace="MsgStatement$Pu" />
+      <node id="6332851714983843199" at="407,0,408,0" concept="8" trace="PropertyAttribute$Gb" />
+      <node id="6332851714983843199" at="411,0,412,0" concept="8" trace="severity$lcf9" />
+      <node id="6332851714983843199" at="415,0,416,0" concept="8" trace="message$I3Bb" />
+      <node id="6332851714983843199" at="416,0,417,0" concept="8" trace="hint$bvDr" />
+      <node id="6332851714983843199" at="417,0,418,0" concept="8" trace="project$OYlE" />
+      <node id="6332851714983843199" at="418,0,419,0" concept="8" trace="throwable$I3Qc" />
       <node id="6332851714983843199" at="47,0,49,0" concept="2" trace="myNode" />
-      <node id="6332851714983843199" at="125,0,127,0" concept="2" trace="myNode" />
-      <node id="6332851714983843199" at="197,0,199,0" concept="2" trace="myNode" />
-      <node id="6332851714983843199" at="272,0,274,0" concept="2" trace="myNode" />
+      <node id="6332851714983843199" at="126,0,128,0" concept="2" trace="myNode" />
+      <node id="6332851714983843199" at="198,0,200,0" concept="2" trace="myNode" />
+      <node id="6332851714983843199" at="270,0,272,0" concept="2" trace="myNode" />
+      <node id="6332851714983843199" at="345,0,347,0" concept="2" trace="myNode" />
       <node id="6332851714983843199" at="61,0,64,0" concept="4" trace="createCell#()Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
-      <node id="6332851714983843202" at="107,0,110,0" concept="4" trace="accept#(Lorg/jetbrains/mps/openapi/model/SNode;)Z" />
-      <node id="6332851714983843199" at="149,87,152,7" concept="3" />
-      <node id="6332851714983843199" at="152,7,155,7" concept="3" />
-      <node id="6332851714983843199" at="171,0,174,0" concept="4" trace="getNoTargetText#()Ljava/lang/String;" />
-      <node id="6332851714983843199" at="221,87,224,7" concept="3" />
-      <node id="6332851714983843199" at="224,7,227,7" concept="3" />
-      <node id="6332851714983843199" at="243,0,246,0" concept="4" trace="getNoTargetText#()Ljava/lang/String;" />
-      <node id="6332851714983843199" at="296,87,299,7" concept="3" />
-      <node id="6332851714983843199" at="299,7,302,7" concept="3" />
-      <node id="6332851714983843199" at="318,0,321,0" concept="4" trace="getNoTargetText#()Ljava/lang/String;" />
+      <node id="6332851714983843202" at="108,0,111,0" concept="4" trace="accept#(Lorg/jetbrains/mps/openapi/model/SNode;)Z" />
+      <node id="6332851714983843199" at="150,87,153,7" concept="3" />
+      <node id="6332851714983843199" at="153,7,156,7" concept="3" />
+      <node id="6332851714983843199" at="172,0,175,0" concept="4" trace="getNoTargetText#()Ljava/lang/String;" />
+      <node id="6332851714983843199" at="222,87,225,7" concept="3" />
+      <node id="6332851714983843199" at="225,7,228,7" concept="3" />
+      <node id="6332851714983843199" at="244,0,247,0" concept="4" trace="getNoTargetText#()Ljava/lang/String;" />
+      <node id="6332851714983843199" at="294,87,297,7" concept="3" />
+      <node id="6332851714983843199" at="297,7,300,7" concept="3" />
+      <node id="6332851714983843199" at="316,0,319,0" concept="4" trace="getNoTargetText#()Ljava/lang/String;" />
+      <node id="6332851714983843199" at="369,87,372,7" concept="3" />
+      <node id="6332851714983843199" at="372,7,375,7" concept="3" />
+      <node id="6332851714983843199" at="391,0,394,0" concept="4" trace="getNoTargetText#()Ljava/lang/String;" />
       <node id="6332851714983843199" at="50,0,54,0" concept="0" trace="MsgStatement_EditorBuilder_a#(Ljetbrains/mps/openapi/editor/EditorContext;Lorg/jetbrains/mps/openapi/model/SNode;)V" />
-      <node id="6332851714983843199" at="120,0,124,0" concept="4" trace="createRefNode_0#()Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
-      <node id="6332851714983843199" at="128,0,132,0" concept="0" trace="messageSingleRoleHandler_tetib3_c0#(Lorg/jetbrains/mps/openapi/model/SNode;Lorg/jetbrains/mps/openapi/language/SContainmentLink;Ljetbrains/mps/openapi/editor/EditorContext;)V" />
-      <node id="6332851714983843199" at="192,0,196,0" concept="4" trace="createRefNode_1#()Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
-      <node id="6332851714983843199" at="200,0,204,0" concept="0" trace="projectSingleRoleHandler_tetib3_b3a#(Lorg/jetbrains/mps/openapi/model/SNode;Lorg/jetbrains/mps/openapi/language/SContainmentLink;Ljetbrains/mps/openapi/editor/EditorContext;)V" />
-      <node id="6332851714983843199" at="267,0,271,0" concept="4" trace="createRefNode_2#()Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
-      <node id="6332851714983843199" at="275,0,279,0" concept="0" trace="throwableSingleRoleHandler_tetib3_b4a#(Lorg/jetbrains/mps/openapi/model/SNode;Lorg/jetbrains/mps/openapi/language/SContainmentLink;Ljetbrains/mps/openapi/editor/EditorContext;)V" />
+      <node id="6332851714983843199" at="121,0,125,0" concept="4" trace="createRefNode_0#()Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
+      <node id="6332851714983843199" at="129,0,133,0" concept="0" trace="messageSingleRoleHandler_tetib3_c0#(Lorg/jetbrains/mps/openapi/model/SNode;Lorg/jetbrains/mps/openapi/language/SContainmentLink;Ljetbrains/mps/openapi/editor/EditorContext;)V" />
+      <node id="6332851714983843199" at="193,0,197,0" concept="4" trace="createRefNode_1#()Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
+      <node id="6332851714983843199" at="201,0,205,0" concept="0" trace="hintSingleRoleHandler_tetib3_b3a#(Lorg/jetbrains/mps/openapi/model/SNode;Lorg/jetbrains/mps/openapi/language/SContainmentLink;Ljetbrains/mps/openapi/editor/EditorContext;)V" />
+      <node id="6332851714983843199" at="265,0,269,0" concept="4" trace="createRefNode_2#()Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
+      <node id="6332851714983843199" at="273,0,277,0" concept="0" trace="projectSingleRoleHandler_tetib3_b4a#(Lorg/jetbrains/mps/openapi/model/SNode;Lorg/jetbrains/mps/openapi/language/SContainmentLink;Ljetbrains/mps/openapi/editor/EditorContext;)V" />
+      <node id="6332851714983843199" at="340,0,344,0" concept="4" trace="createRefNode_3#()Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
+      <node id="6332851714983843199" at="348,0,352,0" concept="0" trace="throwableSingleRoleHandler_tetib3_b5a#(Lorg/jetbrains/mps/openapi/model/SNode;Lorg/jetbrains/mps/openapi/language/SContainmentLink;Ljetbrains/mps/openapi/editor/EditorContext;)V" />
       <node id="6332851714983843199" at="55,0,60,0" concept="4" trace="getNode#()Lorg/jetbrains/mps/openapi/model/SNode;" />
-      <node id="6332851714983843202" at="105,155,110,9" concept="5" />
-      <node id="6332851714983843202" at="110,9,115,24" concept="3" />
-      <node id="6332851714983843199" at="133,0,138,0" concept="4" trace="getNode#()Lorg/jetbrains/mps/openapi/model/SNode;" />
-      <node id="6332851714983843199" at="205,0,210,0" concept="4" trace="getNode#()Lorg/jetbrains/mps/openapi/model/SNode;" />
-      <node id="6332851714983843199" at="280,0,285,0" concept="4" trace="getNode#()Lorg/jetbrains/mps/openapi/model/SNode;" />
-      <node id="6332851714983843199" at="139,0,146,0" concept="4" trace="createChildCell#(Lorg/jetbrains/mps/openapi/model/SNode;)Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
-      <node id="6332851714983843199" at="175,0,182,0" concept="4" trace="createCollection_1#()Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
-      <node id="6332851714983843199" at="211,0,218,0" concept="4" trace="createChildCell#(Lorg/jetbrains/mps/openapi/model/SNode;)Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
-      <node id="6332851714983843199" at="286,0,293,0" concept="4" trace="createChildCell#(Lorg/jetbrains/mps/openapi/model/SNode;)Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
-      <node id="6332851714983843199" at="149,0,157,0" concept="4" trace="installCellInfo#(Lorg/jetbrains/mps/openapi/model/SNode;Ljetbrains/mps/openapi/editor/cells/EditorCell;Z)V" />
-      <node id="6332851714983843199" at="221,0,229,0" concept="4" trace="installCellInfo#(Lorg/jetbrains/mps/openapi/model/SNode;Ljetbrains/mps/openapi/editor/cells/EditorCell;Z)V" />
-      <node id="6332851714983843199" at="296,0,304,0" concept="4" trace="installCellInfo#(Lorg/jetbrains/mps/openapi/model/SNode;Ljetbrains/mps/openapi/editor/cells/EditorCell;Z)V" />
-      <node id="6332851714983843199" at="160,107,169,7" concept="10" />
-      <node id="6332851714983843199" at="232,107,241,7" concept="10" />
-      <node id="6332851714983843199" at="307,109,316,7" concept="10" />
-      <node id="6332851714983843225" at="322,0,331,0" concept="4" trace="createConstant_3#()Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
-      <node id="6332851714983843207" at="182,0,192,0" concept="4" trace="createConstant_1#()Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
-      <node id="6332851714983843199" at="247,0,257,0" concept="4" trace="createCollection_2#()Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
-      <node id="6332851714983843220" at="257,0,267,0" concept="4" trace="createConstant_2#()Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
-      <node id="6332851714983843199" at="65,0,78,0" concept="4" trace="createCollection_0#()Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
-      <node id="5721587534047314498" at="78,0,91,0" concept="4" trace="createConstant_0#()Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
-      <node id="6332851714983843199" at="157,0,171,0" concept="4" trace="createEmptyCell#()Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
-      <node id="6332851714983843199" at="229,0,243,0" concept="4" trace="createEmptyCell#()Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
-      <node id="6332851714983843199" at="304,0,318,0" concept="4" trace="createEmptyCell#()Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
-      <node id="6332851714983843202" at="92,39,118,5" concept="10" />
-      <node id="6332851714983843202" at="91,0,120,0" concept="4" trace="createProperty_0#()Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
+      <node id="6332851714983843202" at="106,155,111,9" concept="5" />
+      <node id="6332851714983843202" at="111,9,116,24" concept="3" />
+      <node id="6332851714983843199" at="134,0,139,0" concept="4" trace="getNode#()Lorg/jetbrains/mps/openapi/model/SNode;" />
+      <node id="6332851714983843199" at="206,0,211,0" concept="4" trace="getNode#()Lorg/jetbrains/mps/openapi/model/SNode;" />
+      <node id="6332851714983843199" at="278,0,283,0" concept="4" trace="getNode#()Lorg/jetbrains/mps/openapi/model/SNode;" />
+      <node id="6332851714983843199" at="353,0,358,0" concept="4" trace="getNode#()Lorg/jetbrains/mps/openapi/model/SNode;" />
+      <node id="6332851714983843199" at="140,0,147,0" concept="4" trace="createChildCell#(Lorg/jetbrains/mps/openapi/model/SNode;)Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
+      <node id="6332851714983843199" at="176,0,183,0" concept="4" trace="createCollection_1#()Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
+      <node id="6332851714983843199" at="212,0,219,0" concept="4" trace="createChildCell#(Lorg/jetbrains/mps/openapi/model/SNode;)Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
+      <node id="6332851714983843199" at="248,0,255,0" concept="4" trace="createCollection_2#()Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
+      <node id="6332851714983843199" at="284,0,291,0" concept="4" trace="createChildCell#(Lorg/jetbrains/mps/openapi/model/SNode;)Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
+      <node id="6332851714983843199" at="359,0,366,0" concept="4" trace="createChildCell#(Lorg/jetbrains/mps/openapi/model/SNode;)Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
+      <node id="6332851714983843199" at="150,0,158,0" concept="4" trace="installCellInfo#(Lorg/jetbrains/mps/openapi/model/SNode;Ljetbrains/mps/openapi/editor/cells/EditorCell;Z)V" />
+      <node id="6332851714983843199" at="222,0,230,0" concept="4" trace="installCellInfo#(Lorg/jetbrains/mps/openapi/model/SNode;Ljetbrains/mps/openapi/editor/cells/EditorCell;Z)V" />
+      <node id="6332851714983843199" at="294,0,302,0" concept="4" trace="installCellInfo#(Lorg/jetbrains/mps/openapi/model/SNode;Ljetbrains/mps/openapi/editor/cells/EditorCell;Z)V" />
+      <node id="6332851714983843199" at="369,0,377,0" concept="4" trace="installCellInfo#(Lorg/jetbrains/mps/openapi/model/SNode;Ljetbrains/mps/openapi/editor/cells/EditorCell;Z)V" />
+      <node id="6332851714983843199" at="161,107,170,7" concept="10" />
+      <node id="6332851714983843199" at="233,104,242,7" concept="10" />
+      <node id="6332851714983843199" at="305,107,314,7" concept="10" />
+      <node id="6332851714983843199" at="380,109,389,7" concept="10" />
+      <node id="6332851714983843225" at="395,0,404,0" concept="4" trace="createConstant_4#()Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
+      <node id="6332851714983843207" at="183,0,193,0" concept="4" trace="createConstant_1#()Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
+      <node id="2096919206290110188" at="255,0,265,0" concept="4" trace="createConstant_2#()Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
+      <node id="6332851714983843199" at="320,0,330,0" concept="4" trace="createCollection_3#()Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
+      <node id="6332851714983843220" at="330,0,340,0" concept="4" trace="createConstant_3#()Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
+      <node id="5721587534047314498" at="79,0,92,0" concept="4" trace="createConstant_0#()Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
+      <node id="6332851714983843199" at="65,0,79,0" concept="4" trace="createCollection_0#()Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
+      <node id="6332851714983843199" at="158,0,172,0" concept="4" trace="createEmptyCell#()Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
+      <node id="6332851714983843199" at="230,0,244,0" concept="4" trace="createEmptyCell#()Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
+      <node id="6332851714983843199" at="302,0,316,0" concept="4" trace="createEmptyCell#()Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
+      <node id="6332851714983843199" at="377,0,391,0" concept="4" trace="createEmptyCell#()Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
+      <node id="6332851714983843202" at="93,39,119,5" concept="10" />
+      <node id="6332851714983843202" at="92,0,121,0" concept="4" trace="createProperty_0#()Ljetbrains/mps/openapi/editor/cells/EditorCell;" />
       <scope id="6332851714983843199" at="57,26,58,18" />
       <scope id="6332851714983843199" at="61,39,62,32" />
-      <scope id="6332851714983843202" at="107,41,108,118" />
-      <scope id="6332851714983843202" at="116,15,117,40" />
-      <scope id="6332851714983843199" at="135,28,136,20" />
-      <scope id="6332851714983843199" at="150,118,151,137" />
-      <scope id="6332851714983843199" at="153,42,154,48" />
-      <scope id="6332851714983843199" at="167,17,168,42" />
-      <scope id="6332851714983843199" at="171,40,172,28" />
-      <scope id="6332851714983843199" at="207,28,208,20" />
-      <scope id="6332851714983843199" at="222,118,223,137" />
-      <scope id="6332851714983843199" at="225,42,226,48" />
-      <scope id="6332851714983843199" at="239,17,240,42" />
-      <scope id="6332851714983843199" at="243,40,244,28" />
-      <scope id="6332851714983843199" at="282,28,283,20" />
-      <scope id="6332851714983843199" at="297,118,298,137" />
-      <scope id="6332851714983843199" at="300,42,301,50" />
-      <scope id="6332851714983843199" at="314,17,315,42" />
-      <scope id="6332851714983843199" at="318,40,319,30" />
+      <scope id="6332851714983843202" at="108,41,109,118" />
+      <scope id="6332851714983843202" at="117,15,118,40" />
+      <scope id="6332851714983843199" at="136,28,137,20" />
+      <scope id="6332851714983843199" at="151,118,152,137" />
+      <scope id="6332851714983843199" at="154,42,155,48" />
+      <scope id="6332851714983843199" at="168,17,169,42" />
+      <scope id="6332851714983843199" at="172,40,173,28" />
+      <scope id="6332851714983843199" at="208,28,209,20" />
+      <scope id="6332851714983843199" at="223,118,224,137" />
+      <scope id="6332851714983843199" at="226,42,227,45" />
+      <scope id="6332851714983843199" at="240,17,241,42" />
+      <scope id="6332851714983843199" at="244,40,245,25" />
+      <scope id="6332851714983843199" at="280,28,281,20" />
+      <scope id="6332851714983843199" at="295,118,296,137" />
+      <scope id="6332851714983843199" at="298,42,299,48" />
+      <scope id="6332851714983843199" at="312,17,313,42" />
+      <scope id="6332851714983843199" at="316,40,317,28" />
+      <scope id="6332851714983843199" at="355,28,356,20" />
+      <scope id="6332851714983843199" at="370,118,371,137" />
+      <scope id="6332851714983843199" at="373,42,374,50" />
+      <scope id="6332851714983843199" at="387,17,388,42" />
+      <scope id="6332851714983843199" at="391,40,392,30" />
       <scope id="6332851714983843199" at="50,92,52,18" />
-      <scope id="6332851714983843202" at="111,74,113,145">
+      <scope id="6332851714983843202" at="112,74,114,145">
         <var name="manager" id="6332851714983843202" />
       </scope>
-      <scope id="6332851714983843199" at="120,40,122,33">
+      <scope id="6332851714983843199" at="121,40,123,33">
         <var name="provider" id="6332851714983843199" />
       </scope>
-      <scope id="6332851714983843199" at="128,121,130,25" />
-      <scope id="6332851714983843199" at="192,40,194,33">
+      <scope id="6332851714983843199" at="129,121,131,25" />
+      <scope id="6332851714983843199" at="193,40,195,33">
         <var name="provider" id="6332851714983843199" />
       </scope>
-      <scope id="6332851714983843199" at="200,122,202,25" />
-      <scope id="6332851714983843199" at="267,40,269,33">
+      <scope id="6332851714983843199" at="201,119,203,25" />
+      <scope id="6332851714983843199" at="265,40,267,33">
         <var name="provider" id="6332851714983843199" />
       </scope>
-      <scope id="6332851714983843199" at="275,124,277,25" />
+      <scope id="6332851714983843199" at="273,122,275,25" />
+      <scope id="6332851714983843199" at="340,40,342,33">
+        <var name="provider" id="6332851714983843199" />
+      </scope>
+      <scope id="6332851714983843199" at="348,124,350,25" />
       <scope id="6332851714983843199" at="61,0,64,0" />
-      <scope id="6332851714983843202" at="107,0,110,0">
+      <scope id="6332851714983843202" at="108,0,111,0">
         <var name="it" id="6332851714983843202" />
       </scope>
-      <scope id="6332851714983843199" at="171,0,174,0" />
-      <scope id="6332851714983843199" at="243,0,246,0" />
-      <scope id="6332851714983843199" at="318,0,321,0" />
+      <scope id="6332851714983843199" at="172,0,175,0" />
+      <scope id="6332851714983843199" at="244,0,247,0" />
+      <scope id="6332851714983843199" at="316,0,319,0" />
+      <scope id="6332851714983843199" at="391,0,394,0" />
       <scope id="6332851714983843199" at="50,0,54,0">
         <var name="context" id="6332851714983843199" />
         <var name="node" id="6332851714983843199" />
       </scope>
-      <scope id="6332851714983843199" at="120,0,124,0" />
-      <scope id="6332851714983843199" at="128,0,132,0">
+      <scope id="6332851714983843199" at="121,0,125,0" />
+      <scope id="6332851714983843199" at="129,0,133,0">
         <var name="containmentLink" id="6332851714983843199" />
         <var name="context" id="6332851714983843199" />
         <var name="ownerNode" id="6332851714983843199" />
       </scope>
-      <scope id="6332851714983843199" at="192,0,196,0" />
-      <scope id="6332851714983843199" at="200,0,204,0">
+      <scope id="6332851714983843199" at="193,0,197,0" />
+      <scope id="6332851714983843199" at="201,0,205,0">
         <var name="containmentLink" id="6332851714983843199" />
         <var name="context" id="6332851714983843199" />
         <var name="ownerNode" id="6332851714983843199" />
       </scope>
-      <scope id="6332851714983843199" at="267,0,271,0" />
-      <scope id="6332851714983843199" at="275,0,279,0">
+      <scope id="6332851714983843199" at="265,0,269,0" />
+      <scope id="6332851714983843199" at="273,0,277,0">
+        <var name="containmentLink" id="6332851714983843199" />
+        <var name="context" id="6332851714983843199" />
+        <var name="ownerNode" id="6332851714983843199" />
+      </scope>
+      <scope id="6332851714983843199" at="340,0,344,0" />
+      <scope id="6332851714983843199" at="348,0,352,0">
         <var name="containmentLink" id="6332851714983843199" />
         <var name="context" id="6332851714983843199" />
         <var name="ownerNode" id="6332851714983843199" />
       </scope>
       <scope id="6332851714983843199" at="55,0,60,0" />
-      <scope id="6332851714983843199" at="133,0,138,0" />
-      <scope id="6332851714983843199" at="139,55,144,24">
+      <scope id="6332851714983843199" at="134,0,139,0" />
+      <scope id="6332851714983843199" at="140,55,145,24">
         <var name="editorCell" id="6332851714983843199" />
       </scope>
-      <scope id="6332851714983843199" at="161,11,166,26">
+      <scope id="6332851714983843199" at="162,11,167,26">
         <var name="editorCell" id="6332851714983843199" />
       </scope>
-      <scope id="6332851714983843199" at="175,43,180,22">
+      <scope id="6332851714983843199" at="176,43,181,22">
         <var name="editorCell" id="6332851714983843199" />
       </scope>
-      <scope id="6332851714983843199" at="205,0,210,0" />
-      <scope id="6332851714983843199" at="211,55,216,24">
+      <scope id="6332851714983843199" at="206,0,211,0" />
+      <scope id="6332851714983843199" at="212,55,217,24">
         <var name="editorCell" id="6332851714983843199" />
       </scope>
-      <scope id="6332851714983843199" at="233,11,238,26">
+      <scope id="6332851714983843199" at="234,11,239,26">
         <var name="editorCell" id="6332851714983843199" />
       </scope>
-      <scope id="6332851714983843199" at="280,0,285,0" />
-      <scope id="6332851714983843199" at="286,55,291,24">
+      <scope id="6332851714983843199" at="248,43,253,22">
         <var name="editorCell" id="6332851714983843199" />
       </scope>
-      <scope id="6332851714983843199" at="308,11,313,26">
+      <scope id="6332851714983843199" at="278,0,283,0" />
+      <scope id="6332851714983843199" at="284,55,289,24">
         <var name="editorCell" id="6332851714983843199" />
       </scope>
-      <scope id="6332851714983843199" at="149,87,155,7" />
-      <scope id="6332851714983843199" at="221,87,227,7" />
-      <scope id="6332851714983843199" at="296,87,302,7" />
-      <scope id="6332851714983843199" at="139,0,146,0">
+      <scope id="6332851714983843199" at="306,11,311,26">
+        <var name="editorCell" id="6332851714983843199" />
+      </scope>
+      <scope id="6332851714983843199" at="353,0,358,0" />
+      <scope id="6332851714983843199" at="359,55,364,24">
+        <var name="editorCell" id="6332851714983843199" />
+      </scope>
+      <scope id="6332851714983843199" at="381,11,386,26">
+        <var name="editorCell" id="6332851714983843199" />
+      </scope>
+      <scope id="6332851714983843199" at="150,87,156,7" />
+      <scope id="6332851714983843199" at="222,87,228,7" />
+      <scope id="6332851714983843199" at="294,87,300,7" />
+      <scope id="6332851714983843199" at="369,87,375,7" />
+      <scope id="6332851714983843199" at="140,0,147,0">
         <var name="child" id="6332851714983843199" />
       </scope>
-      <scope id="6332851714983843199" at="175,0,182,0" />
-      <scope id="6332851714983843199" at="211,0,218,0">
+      <scope id="6332851714983843199" at="176,0,183,0" />
+      <scope id="6332851714983843199" at="212,0,219,0">
         <var name="child" id="6332851714983843199" />
       </scope>
-      <scope id="6332851714983843199" at="286,0,293,0">
+      <scope id="6332851714983843199" at="248,0,255,0" />
+      <scope id="6332851714983843199" at="284,0,291,0">
         <var name="child" id="6332851714983843199" />
       </scope>
-      <scope id="6332851714983843225" at="322,41,329,22">
+      <scope id="6332851714983843199" at="359,0,366,0">
+        <var name="child" id="6332851714983843199" />
+      </scope>
+      <scope id="6332851714983843225" at="395,41,402,22">
         <var name="editorCell" id="6332851714983843225" />
         <var name="style" id="6332851714983843225" />
       </scope>
-      <scope id="6332851714983843199" at="149,0,157,0">
+      <scope id="6332851714983843199" at="150,0,158,0">
         <var name="child" id="6332851714983843199" />
         <var name="editorCell" id="6332851714983843199" />
         <var name="isEmpty" id="6332851714983843199" />
       </scope>
-      <scope id="6332851714983843207" at="182,41,190,22">
+      <scope id="6332851714983843207" at="183,41,191,22">
         <var name="editorCell" id="6332851714983843207" />
         <var name="style" id="6332851714983843207" />
       </scope>
-      <scope id="6332851714983843199" at="221,0,229,0">
+      <scope id="6332851714983843199" at="222,0,230,0">
         <var name="child" id="6332851714983843199" />
         <var name="editorCell" id="6332851714983843199" />
         <var name="isEmpty" id="6332851714983843199" />
       </scope>
-      <scope id="6332851714983843199" at="247,43,255,22">
+      <scope id="2096919206290110188" at="255,41,263,22">
+        <var name="editorCell" id="2096919206290110188" />
+        <var name="style" id="2096919206290110188" />
+      </scope>
+      <scope id="6332851714983843199" at="294,0,302,0">
+        <var name="child" id="6332851714983843199" />
+        <var name="editorCell" id="6332851714983843199" />
+        <var name="isEmpty" id="6332851714983843199" />
+      </scope>
+      <scope id="6332851714983843199" at="320,43,328,22">
         <var name="editorCell" id="6332851714983843199" />
         <var name="style" id="6332851714983843199" />
       </scope>
-      <scope id="6332851714983843220" at="257,41,265,22">
+      <scope id="6332851714983843220" at="330,41,338,22">
         <var name="editorCell" id="6332851714983843220" />
         <var name="style" id="6332851714983843220" />
       </scope>
-      <scope id="6332851714983843199" at="296,0,304,0">
+      <scope id="6332851714983843199" at="369,0,377,0">
         <var name="child" id="6332851714983843199" />
         <var name="editorCell" id="6332851714983843199" />
         <var name="isEmpty" id="6332851714983843199" />
       </scope>
-      <scope id="6332851714983843225" at="322,0,331,0" />
-      <scope id="6332851714983843207" at="182,0,192,0" />
-      <scope id="6332851714983843199" at="247,0,257,0" />
-      <scope id="6332851714983843220" at="257,0,267,0" />
-      <scope id="6332851714983843199" at="65,43,76,22">
-        <var name="editorCell" id="6332851714983843199" />
-      </scope>
-      <scope id="5721587534047314498" at="78,41,89,22">
+      <scope id="6332851714983843225" at="395,0,404,0" />
+      <scope id="6332851714983843207" at="183,0,193,0" />
+      <scope id="2096919206290110188" at="255,0,265,0" />
+      <scope id="6332851714983843199" at="320,0,330,0" />
+      <scope id="6332851714983843220" at="330,0,340,0" />
+      <scope id="5721587534047314498" at="79,41,90,22">
         <var name="editorCell" id="5721587534047314498" />
         <var name="style" id="5721587534047314498" />
       </scope>
-      <scope id="6332851714983843199" at="158,44,169,7" />
-      <scope id="6332851714983843199" at="230,44,241,7" />
-      <scope id="6332851714983843199" at="305,44,316,7" />
-      <scope id="6332851714983843199" at="65,0,78,0" />
-      <scope id="5721587534047314498" at="78,0,91,0" />
-      <scope id="6332851714983843199" at="157,0,171,0" />
-      <scope id="6332851714983843199" at="229,0,243,0" />
-      <scope id="6332851714983843199" at="304,0,318,0" />
-      <scope id="6332851714983843202" at="93,9,115,24">
+      <scope id="6332851714983843199" at="159,44,170,7" />
+      <scope id="6332851714983843199" at="231,44,242,7" />
+      <scope id="6332851714983843199" at="303,44,314,7" />
+      <scope id="6332851714983843199" at="378,44,389,7" />
+      <scope id="6332851714983843199" at="65,43,77,22">
+        <var name="editorCell" id="6332851714983843199" />
+      </scope>
+      <scope id="5721587534047314498" at="79,0,92,0" />
+      <scope id="6332851714983843199" at="65,0,79,0" />
+      <scope id="6332851714983843199" at="158,0,172,0" />
+      <scope id="6332851714983843199" at="230,0,244,0" />
+      <scope id="6332851714983843199" at="302,0,316,0" />
+      <scope id="6332851714983843199" at="377,0,391,0" />
+      <scope id="6332851714983843202" at="94,9,116,24">
         <var name="currentPropertyAttributes" id="6332851714983843202" />
         <var name="editorCell" id="6332851714983843202" />
         <var name="property" id="6332851714983843202" />
         <var name="propertyAttributes" id="6332851714983843202" />
         <var name="style" id="6332851714983843202" />
       </scope>
-      <scope id="6332851714983843202" at="91,41,118,5" />
-      <scope id="6332851714983843202" at="91,0,120,0" />
-      <unit id="6332851714983843199" at="337,0,340,0" name="jetbrains.mps.baseLanguage.logging.editor.MsgStatement_EditorBuilder_a$PROPS" />
-      <unit id="6332851714983843202" at="106,102,110,7" name="jetbrains.mps.baseLanguage.logging.editor.MsgStatement_EditorBuilder_a$1" />
-      <unit id="6332851714983843199" at="332,0,336,0" name="jetbrains.mps.baseLanguage.logging.editor.MsgStatement_EditorBuilder_a$CONCEPTS" />
-      <unit id="6332851714983843199" at="341,0,346,0" name="jetbrains.mps.baseLanguage.logging.editor.MsgStatement_EditorBuilder_a$LINKS" />
-      <unit id="6332851714983843199" at="124,0,175,0" name="jetbrains.mps.baseLanguage.logging.editor.MsgStatement_EditorBuilder_a$messageSingleRoleHandler_tetib3_c0" />
-      <unit id="6332851714983843199" at="196,0,247,0" name="jetbrains.mps.baseLanguage.logging.editor.MsgStatement_EditorBuilder_a$projectSingleRoleHandler_tetib3_b3a" />
-      <unit id="6332851714983843199" at="271,0,322,0" name="jetbrains.mps.baseLanguage.logging.editor.MsgStatement_EditorBuilder_a$throwableSingleRoleHandler_tetib3_b4a" />
-      <unit id="6332851714983843199" at="46,0,347,0" name="jetbrains.mps.baseLanguage.logging.editor.MsgStatement_EditorBuilder_a" />
+      <scope id="6332851714983843202" at="92,41,119,5" />
+      <scope id="6332851714983843202" at="92,0,121,0" />
+      <unit id="6332851714983843199" at="410,0,413,0" name="jetbrains.mps.baseLanguage.logging.editor.MsgStatement_EditorBuilder_a$PROPS" />
+      <unit id="6332851714983843202" at="107,102,111,7" name="jetbrains.mps.baseLanguage.logging.editor.MsgStatement_EditorBuilder_a$1" />
+      <unit id="6332851714983843199" at="405,0,409,0" name="jetbrains.mps.baseLanguage.logging.editor.MsgStatement_EditorBuilder_a$CONCEPTS" />
+      <unit id="6332851714983843199" at="414,0,420,0" name="jetbrains.mps.baseLanguage.logging.editor.MsgStatement_EditorBuilder_a$LINKS" />
+      <unit id="6332851714983843199" at="125,0,176,0" name="jetbrains.mps.baseLanguage.logging.editor.MsgStatement_EditorBuilder_a$messageSingleRoleHandler_tetib3_c0" />
+      <unit id="6332851714983843199" at="197,0,248,0" name="jetbrains.mps.baseLanguage.logging.editor.MsgStatement_EditorBuilder_a$hintSingleRoleHandler_tetib3_b3a" />
+      <unit id="6332851714983843199" at="269,0,320,0" name="jetbrains.mps.baseLanguage.logging.editor.MsgStatement_EditorBuilder_a$projectSingleRoleHandler_tetib3_b4a" />
+      <unit id="6332851714983843199" at="344,0,395,0" name="jetbrains.mps.baseLanguage.logging.editor.MsgStatement_EditorBuilder_a$throwableSingleRoleHandler_tetib3_b5a" />
+      <unit id="6332851714983843199" at="46,0,421,0" name="jetbrains.mps.baseLanguage.logging.editor.MsgStatement_EditorBuilder_a" />
     </file>
   </root>
 </debug-info>

--- a/languages/baseLanguage/logging/source_gen/jetbrains/mps/baseLanguage/logging/structure/StructureAspectDescriptor.java
+++ b/languages/baseLanguage/logging/source_gen/jetbrains/mps/baseLanguage/logging/structure/StructureAspectDescriptor.java
@@ -99,6 +99,7 @@ public class StructureAspectDescriptor extends BaseStructureAspectDescriptor {
     b.aggregate("message", 0x4f67298c4630c25eL).target(0xf3061a5392264cc5L, 0xa443f952ceaf5816L, 0xf8c37f506fL).optional(false).ordered(true).multiple(false).origin("5721587534047265374").done();
     b.aggregate("throwable", 0x4f67298c4630c25fL).target(0xf3061a5392264cc5L, 0xa443f952ceaf5816L, 0xf8c37f506fL).optional(true).ordered(true).multiple(false).origin("5721587534047265375").done();
     b.aggregate("project", 0x4f67298c4630c318L).target(0xf3061a5392264cc5L, 0xa443f952ceaf5816L, 0xf8c37f506fL).optional(true).ordered(true).multiple(false).origin("5721587534047265560").done();
+    b.aggregate("hint", 0x1d19c0e87d9d67c2L).target(0xf3061a5392264cc5L, 0xa443f952ceaf5816L, 0xf8c37f506fL).optional(true).ordered(true).multiple(false).origin("2096919206290089922").done();
     b.alias("message");
     return b.create();
   }

--- a/languages/baseLanguage/logging/source_gen/jetbrains/mps/baseLanguage/logging/structure/aspectcps-descriptorclasses.mps
+++ b/languages/baseLanguage/logging/source_gen/jetbrains/mps/baseLanguage/logging/structure/aspectcps-descriptorclasses.mps
@@ -2403,27 +2403,27 @@
       <property role="TrG5h" value="createDescriptorForMsgStatement" />
       <node concept="3clFbS" id="bK" role="3clF47">
         <node concept="3cpWs8" id="bN" role="3cqZAp">
-          <node concept="3cpWsn" id="c0" role="3cpWs9">
+          <node concept="3cpWsn" id="c1" role="3cpWs9">
             <property role="TrG5h" value="b" />
-            <node concept="3uibUv" id="c1" role="1tU5fm">
+            <node concept="3uibUv" id="c2" role="1tU5fm">
               <ref role="3uigEE" to="bzg8:~ConceptDescriptorBuilder2" resolve="ConceptDescriptorBuilder2" />
             </node>
-            <node concept="2ShNRf" id="c2" role="33vP2m">
-              <node concept="1pGfFk" id="c3" role="2ShVmc">
+            <node concept="2ShNRf" id="c3" role="33vP2m">
+              <node concept="1pGfFk" id="c4" role="2ShVmc">
                 <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2.&lt;init&gt;(java.lang.String,java.lang.String,long,long,long)" resolve="ConceptDescriptorBuilder2" />
-                <node concept="Xl_RD" id="c4" role="37wK5m">
+                <node concept="Xl_RD" id="c5" role="37wK5m">
                   <property role="Xl_RC" value="jetbrains.mps.baseLanguage.logging" />
                 </node>
-                <node concept="Xl_RD" id="c5" role="37wK5m">
+                <node concept="Xl_RD" id="c6" role="37wK5m">
                   <property role="Xl_RC" value="MsgStatement" />
                 </node>
-                <node concept="1adDum" id="c6" role="37wK5m">
+                <node concept="1adDum" id="c7" role="37wK5m">
                   <property role="1adDun" value="0x760a0a8ceabb4521L" />
                 </node>
-                <node concept="1adDum" id="c7" role="37wK5m">
+                <node concept="1adDum" id="c8" role="37wK5m">
                   <property role="1adDun" value="0x8bfd65db761a9ba3L" />
                 </node>
-                <node concept="1adDum" id="c8" role="37wK5m">
+                <node concept="1adDum" id="c9" role="37wK5m">
                   <property role="1adDun" value="0x57e2cf14f6d5a71dL" />
                 </node>
               </node>
@@ -2431,359 +2431,424 @@
           </node>
         </node>
         <node concept="3clFbF" id="bO" role="3cqZAp">
-          <node concept="2OqwBi" id="c9" role="3clFbG">
-            <node concept="37vLTw" id="ca" role="2Oq$k0">
-              <ref role="3cqZAo" node="c0" resolve="b" />
+          <node concept="2OqwBi" id="ca" role="3clFbG">
+            <node concept="37vLTw" id="cb" role="2Oq$k0">
+              <ref role="3cqZAo" node="c1" resolve="b" />
             </node>
-            <node concept="liA8E" id="cb" role="2OqNvi">
+            <node concept="liA8E" id="cc" role="2OqNvi">
               <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2.class_(boolean,boolean,boolean)" resolve="class_" />
-              <node concept="3clFbT" id="cc" role="37wK5m" />
               <node concept="3clFbT" id="cd" role="37wK5m" />
               <node concept="3clFbT" id="ce" role="37wK5m" />
+              <node concept="3clFbT" id="cf" role="37wK5m" />
             </node>
           </node>
         </node>
         <node concept="3SKdUt" id="bP" role="3cqZAp">
-          <node concept="1PaTwC" id="cf" role="1aUNEU">
-            <node concept="3oM_SD" id="cg" role="1PaTwD">
+          <node concept="1PaTwC" id="cg" role="1aUNEU">
+            <node concept="3oM_SD" id="ch" role="1PaTwD">
               <property role="3oM_SC" value="extends:" />
             </node>
-            <node concept="3oM_SD" id="ch" role="1PaTwD">
+            <node concept="3oM_SD" id="ci" role="1PaTwD">
               <property role="3oM_SC" value="jetbrains.mps.baseLanguage.structure.Statement" />
             </node>
           </node>
         </node>
         <node concept="3clFbF" id="bQ" role="3cqZAp">
-          <node concept="15s5l7" id="ci" role="lGtFl">
+          <node concept="15s5l7" id="cj" role="lGtFl">
             <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: wrong number of parameters&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c895902c5(jetbrains.mps.baseLanguage.typesystem)/1219948518456]&quot;;" />
             <property role="huDt6" value="Error: wrong number of parameters" />
           </node>
-          <node concept="2OqwBi" id="cj" role="3clFbG">
-            <node concept="37vLTw" id="ck" role="2Oq$k0">
-              <ref role="3cqZAo" node="c0" resolve="b" />
+          <node concept="2OqwBi" id="ck" role="3clFbG">
+            <node concept="37vLTw" id="cl" role="2Oq$k0">
+              <ref role="3cqZAo" node="c1" resolve="b" />
             </node>
-            <node concept="liA8E" id="cl" role="2OqNvi">
+            <node concept="liA8E" id="cm" role="2OqNvi">
               <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2.super_(long,long,long)" resolve="super_" />
-              <node concept="1adDum" id="cm" role="37wK5m">
+              <node concept="1adDum" id="cn" role="37wK5m">
                 <property role="1adDun" value="0xf3061a5392264cc5L" />
               </node>
-              <node concept="1adDum" id="cn" role="37wK5m">
+              <node concept="1adDum" id="co" role="37wK5m">
                 <property role="1adDun" value="0xa443f952ceaf5816L" />
               </node>
-              <node concept="1adDum" id="co" role="37wK5m">
+              <node concept="1adDum" id="cp" role="37wK5m">
                 <property role="1adDun" value="0xf8cc56b215L" />
               </node>
             </node>
           </node>
         </node>
         <node concept="3clFbF" id="bR" role="3cqZAp">
-          <node concept="2OqwBi" id="cp" role="3clFbG">
-            <node concept="37vLTw" id="cq" role="2Oq$k0">
+          <node concept="2OqwBi" id="cq" role="3clFbG">
+            <node concept="37vLTw" id="cr" role="2Oq$k0">
               <ref role="3cqZAo" node="9s" resolve="b" />
             </node>
-            <node concept="liA8E" id="cr" role="2OqNvi">
+            <node concept="liA8E" id="cs" role="2OqNvi">
               <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2.parent(long,long,long)" resolve="parent" />
-              <node concept="1adDum" id="cs" role="37wK5m">
+              <node concept="1adDum" id="ct" role="37wK5m">
                 <property role="1adDun" value="0x760a0a8ceabb4521L" />
               </node>
-              <node concept="1adDum" id="ct" role="37wK5m">
+              <node concept="1adDum" id="cu" role="37wK5m">
                 <property role="1adDun" value="0x8bfd65db761a9ba3L" />
               </node>
-              <node concept="1adDum" id="cu" role="37wK5m">
+              <node concept="1adDum" id="cv" role="37wK5m">
                 <property role="1adDun" value="0x57e2cf14f6d5eeb6L" />
               </node>
             </node>
           </node>
         </node>
         <node concept="3clFbF" id="bS" role="3cqZAp">
-          <node concept="2OqwBi" id="cv" role="3clFbG">
-            <node concept="37vLTw" id="cw" role="2Oq$k0">
-              <ref role="3cqZAo" node="c0" resolve="b" />
+          <node concept="2OqwBi" id="cw" role="3clFbG">
+            <node concept="37vLTw" id="cx" role="2Oq$k0">
+              <ref role="3cqZAo" node="c1" resolve="b" />
             </node>
-            <node concept="liA8E" id="cx" role="2OqNvi">
+            <node concept="liA8E" id="cy" role="2OqNvi">
               <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2.origin(java.lang.String)" resolve="origin" />
-              <node concept="Xl_RD" id="cy" role="37wK5m">
+              <node concept="Xl_RD" id="cz" role="37wK5m">
                 <property role="Xl_RC" value="r:00000000-0000-4000-0000-011c8959057f(jetbrains.mps.baseLanguage.logging.structure)/6332851714983831325" />
               </node>
             </node>
           </node>
         </node>
         <node concept="3clFbF" id="bT" role="3cqZAp">
-          <node concept="2OqwBi" id="cz" role="3clFbG">
-            <node concept="37vLTw" id="c$" role="2Oq$k0">
-              <ref role="3cqZAo" node="c0" resolve="b" />
+          <node concept="2OqwBi" id="c$" role="3clFbG">
+            <node concept="37vLTw" id="c_" role="2Oq$k0">
+              <ref role="3cqZAo" node="c1" resolve="b" />
             </node>
-            <node concept="liA8E" id="c_" role="2OqNvi">
+            <node concept="liA8E" id="cA" role="2OqNvi">
               <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2.version(int)" resolve="version" />
-              <node concept="3cmrfG" id="cA" role="37wK5m">
+              <node concept="3cmrfG" id="cB" role="37wK5m">
                 <property role="3cmrfH" value="3" />
               </node>
             </node>
           </node>
         </node>
         <node concept="3clFbF" id="bU" role="3cqZAp">
-          <node concept="2OqwBi" id="cB" role="3clFbG">
-            <node concept="2OqwBi" id="cC" role="2Oq$k0">
-              <node concept="2OqwBi" id="cE" role="2Oq$k0">
-                <node concept="2OqwBi" id="cG" role="2Oq$k0">
-                  <node concept="37vLTw" id="cI" role="2Oq$k0">
-                    <ref role="3cqZAo" node="c0" resolve="b" />
+          <node concept="2OqwBi" id="cC" role="3clFbG">
+            <node concept="2OqwBi" id="cD" role="2Oq$k0">
+              <node concept="2OqwBi" id="cF" role="2Oq$k0">
+                <node concept="2OqwBi" id="cH" role="2Oq$k0">
+                  <node concept="37vLTw" id="cJ" role="2Oq$k0">
+                    <ref role="3cqZAo" node="c1" resolve="b" />
                   </node>
-                  <node concept="liA8E" id="cJ" role="2OqNvi">
+                  <node concept="liA8E" id="cK" role="2OqNvi">
                     <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2.property(java.lang.String,long)" resolve="property" />
-                    <node concept="Xl_RD" id="cK" role="37wK5m">
+                    <node concept="Xl_RD" id="cL" role="37wK5m">
                       <property role="Xl_RC" value="severity" />
                     </node>
-                    <node concept="1adDum" id="cL" role="37wK5m">
+                    <node concept="1adDum" id="cM" role="37wK5m">
                       <property role="1adDun" value="0x57e2cf14f6d5d81fL" />
                     </node>
                   </node>
                 </node>
-                <node concept="liA8E" id="cH" role="2OqNvi">
+                <node concept="liA8E" id="cI" role="2OqNvi">
                   <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2$PropertyBuilder.type(jetbrains.mps.smodel.adapter.ids.STypeId)" resolve="type" />
-                  <node concept="2YIFZM" id="cM" role="37wK5m">
+                  <node concept="2YIFZM" id="cN" role="37wK5m">
                     <ref role="37wK5l" to="e8bb:~MetaIdFactory.dataTypeId(long,long,long)" resolve="dataTypeId" />
                     <ref role="1Pybhc" to="e8bb:~MetaIdFactory" resolve="MetaIdFactory" />
                     <uo k="s:originTrace" v="n:4241665505353445541" />
-                    <node concept="1adDum" id="cN" role="37wK5m">
+                    <node concept="1adDum" id="cO" role="37wK5m">
                       <property role="1adDun" value="0x760a0a8ceabb4521L" />
                       <uo k="s:originTrace" v="n:4241665505353445541" />
                     </node>
-                    <node concept="1adDum" id="cO" role="37wK5m">
+                    <node concept="1adDum" id="cP" role="37wK5m">
                       <property role="1adDun" value="0x8bfd65db761a9ba3L" />
                       <uo k="s:originTrace" v="n:4241665505353445541" />
                     </node>
-                    <node concept="1adDum" id="cP" role="37wK5m">
+                    <node concept="1adDum" id="cQ" role="37wK5m">
                       <property role="1adDun" value="0x10fc53ae113L" />
                       <uo k="s:originTrace" v="n:4241665505353445541" />
                     </node>
                   </node>
                 </node>
               </node>
-              <node concept="liA8E" id="cF" role="2OqNvi">
+              <node concept="liA8E" id="cG" role="2OqNvi">
                 <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2$PropertyBuilder.origin(java.lang.String)" resolve="origin" />
-                <node concept="Xl_RD" id="cQ" role="37wK5m">
+                <node concept="Xl_RD" id="cR" role="37wK5m">
                   <property role="Xl_RC" value="4241665505353453576" />
                 </node>
               </node>
             </node>
-            <node concept="liA8E" id="cD" role="2OqNvi">
+            <node concept="liA8E" id="cE" role="2OqNvi">
               <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2$PropertyBuilder.done()" resolve="done" />
             </node>
           </node>
         </node>
         <node concept="3clFbF" id="bV" role="3cqZAp">
-          <node concept="2OqwBi" id="cR" role="3clFbG">
-            <node concept="2OqwBi" id="cS" role="2Oq$k0">
-              <node concept="2OqwBi" id="cU" role="2Oq$k0">
-                <node concept="2OqwBi" id="cW" role="2Oq$k0">
-                  <node concept="2OqwBi" id="cY" role="2Oq$k0">
-                    <node concept="2OqwBi" id="d0" role="2Oq$k0">
-                      <node concept="2OqwBi" id="d2" role="2Oq$k0">
-                        <node concept="37vLTw" id="d4" role="2Oq$k0">
-                          <ref role="3cqZAo" node="c0" resolve="b" />
+          <node concept="2OqwBi" id="cS" role="3clFbG">
+            <node concept="2OqwBi" id="cT" role="2Oq$k0">
+              <node concept="2OqwBi" id="cV" role="2Oq$k0">
+                <node concept="2OqwBi" id="cX" role="2Oq$k0">
+                  <node concept="2OqwBi" id="cZ" role="2Oq$k0">
+                    <node concept="2OqwBi" id="d1" role="2Oq$k0">
+                      <node concept="2OqwBi" id="d3" role="2Oq$k0">
+                        <node concept="37vLTw" id="d5" role="2Oq$k0">
+                          <ref role="3cqZAo" node="c1" resolve="b" />
                         </node>
-                        <node concept="liA8E" id="d5" role="2OqNvi">
+                        <node concept="liA8E" id="d6" role="2OqNvi">
                           <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2.aggregate(java.lang.String,long)" resolve="aggregate" />
-                          <node concept="Xl_RD" id="d6" role="37wK5m">
+                          <node concept="Xl_RD" id="d7" role="37wK5m">
                             <property role="Xl_RC" value="message" />
                           </node>
-                          <node concept="1adDum" id="d7" role="37wK5m">
+                          <node concept="1adDum" id="d8" role="37wK5m">
                             <property role="1adDun" value="0x4f67298c4630c25eL" />
                           </node>
                         </node>
                       </node>
-                      <node concept="liA8E" id="d3" role="2OqNvi">
+                      <node concept="liA8E" id="d4" role="2OqNvi">
                         <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2$AggregationLinkBuilder.target(long,long,long)" resolve="target" />
-                        <node concept="1adDum" id="d8" role="37wK5m">
+                        <node concept="1adDum" id="d9" role="37wK5m">
                           <property role="1adDun" value="0xf3061a5392264cc5L" />
                         </node>
-                        <node concept="1adDum" id="d9" role="37wK5m">
+                        <node concept="1adDum" id="da" role="37wK5m">
                           <property role="1adDun" value="0xa443f952ceaf5816L" />
                         </node>
-                        <node concept="1adDum" id="da" role="37wK5m">
+                        <node concept="1adDum" id="db" role="37wK5m">
                           <property role="1adDun" value="0xf8c37f506fL" />
                         </node>
                       </node>
                     </node>
-                    <node concept="liA8E" id="d1" role="2OqNvi">
+                    <node concept="liA8E" id="d2" role="2OqNvi">
                       <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2$AggregationLinkBuilder.optional(boolean)" resolve="optional" />
-                      <node concept="3clFbT" id="db" role="37wK5m" />
+                      <node concept="3clFbT" id="dc" role="37wK5m" />
                     </node>
                   </node>
-                  <node concept="liA8E" id="cZ" role="2OqNvi">
+                  <node concept="liA8E" id="d0" role="2OqNvi">
                     <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2$AggregationLinkBuilder.ordered(boolean)" resolve="ordered" />
-                    <node concept="3clFbT" id="dc" role="37wK5m">
+                    <node concept="3clFbT" id="dd" role="37wK5m">
                       <property role="3clFbU" value="true" />
                     </node>
                   </node>
                 </node>
-                <node concept="liA8E" id="cX" role="2OqNvi">
+                <node concept="liA8E" id="cY" role="2OqNvi">
                   <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2$AggregationLinkBuilder.multiple(boolean)" resolve="multiple" />
-                  <node concept="3clFbT" id="dd" role="37wK5m" />
+                  <node concept="3clFbT" id="de" role="37wK5m" />
                 </node>
               </node>
-              <node concept="liA8E" id="cV" role="2OqNvi">
+              <node concept="liA8E" id="cW" role="2OqNvi">
                 <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2$AggregationLinkBuilder.origin(java.lang.String)" resolve="origin" />
-                <node concept="Xl_RD" id="de" role="37wK5m">
+                <node concept="Xl_RD" id="df" role="37wK5m">
                   <property role="Xl_RC" value="5721587534047265374" />
                 </node>
               </node>
             </node>
-            <node concept="liA8E" id="cT" role="2OqNvi">
+            <node concept="liA8E" id="cU" role="2OqNvi">
               <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2$AggregationLinkBuilder.done()" resolve="done" />
             </node>
           </node>
         </node>
         <node concept="3clFbF" id="bW" role="3cqZAp">
-          <node concept="2OqwBi" id="df" role="3clFbG">
-            <node concept="2OqwBi" id="dg" role="2Oq$k0">
-              <node concept="2OqwBi" id="di" role="2Oq$k0">
-                <node concept="2OqwBi" id="dk" role="2Oq$k0">
-                  <node concept="2OqwBi" id="dm" role="2Oq$k0">
-                    <node concept="2OqwBi" id="do" role="2Oq$k0">
-                      <node concept="2OqwBi" id="dq" role="2Oq$k0">
-                        <node concept="37vLTw" id="ds" role="2Oq$k0">
-                          <ref role="3cqZAo" node="c0" resolve="b" />
+          <node concept="2OqwBi" id="dg" role="3clFbG">
+            <node concept="2OqwBi" id="dh" role="2Oq$k0">
+              <node concept="2OqwBi" id="dj" role="2Oq$k0">
+                <node concept="2OqwBi" id="dl" role="2Oq$k0">
+                  <node concept="2OqwBi" id="dn" role="2Oq$k0">
+                    <node concept="2OqwBi" id="dp" role="2Oq$k0">
+                      <node concept="2OqwBi" id="dr" role="2Oq$k0">
+                        <node concept="37vLTw" id="dt" role="2Oq$k0">
+                          <ref role="3cqZAo" node="c1" resolve="b" />
                         </node>
-                        <node concept="liA8E" id="dt" role="2OqNvi">
+                        <node concept="liA8E" id="du" role="2OqNvi">
                           <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2.aggregate(java.lang.String,long)" resolve="aggregate" />
-                          <node concept="Xl_RD" id="du" role="37wK5m">
+                          <node concept="Xl_RD" id="dv" role="37wK5m">
                             <property role="Xl_RC" value="throwable" />
                           </node>
-                          <node concept="1adDum" id="dv" role="37wK5m">
+                          <node concept="1adDum" id="dw" role="37wK5m">
                             <property role="1adDun" value="0x4f67298c4630c25fL" />
                           </node>
                         </node>
                       </node>
-                      <node concept="liA8E" id="dr" role="2OqNvi">
+                      <node concept="liA8E" id="ds" role="2OqNvi">
                         <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2$AggregationLinkBuilder.target(long,long,long)" resolve="target" />
-                        <node concept="1adDum" id="dw" role="37wK5m">
+                        <node concept="1adDum" id="dx" role="37wK5m">
                           <property role="1adDun" value="0xf3061a5392264cc5L" />
                         </node>
-                        <node concept="1adDum" id="dx" role="37wK5m">
+                        <node concept="1adDum" id="dy" role="37wK5m">
                           <property role="1adDun" value="0xa443f952ceaf5816L" />
                         </node>
-                        <node concept="1adDum" id="dy" role="37wK5m">
+                        <node concept="1adDum" id="dz" role="37wK5m">
                           <property role="1adDun" value="0xf8c37f506fL" />
                         </node>
                       </node>
                     </node>
-                    <node concept="liA8E" id="dp" role="2OqNvi">
+                    <node concept="liA8E" id="dq" role="2OqNvi">
                       <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2$AggregationLinkBuilder.optional(boolean)" resolve="optional" />
-                      <node concept="3clFbT" id="dz" role="37wK5m">
+                      <node concept="3clFbT" id="d$" role="37wK5m">
                         <property role="3clFbU" value="true" />
                       </node>
                     </node>
                   </node>
-                  <node concept="liA8E" id="dn" role="2OqNvi">
+                  <node concept="liA8E" id="do" role="2OqNvi">
                     <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2$AggregationLinkBuilder.ordered(boolean)" resolve="ordered" />
-                    <node concept="3clFbT" id="d$" role="37wK5m">
+                    <node concept="3clFbT" id="d_" role="37wK5m">
                       <property role="3clFbU" value="true" />
                     </node>
                   </node>
                 </node>
-                <node concept="liA8E" id="dl" role="2OqNvi">
+                <node concept="liA8E" id="dm" role="2OqNvi">
                   <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2$AggregationLinkBuilder.multiple(boolean)" resolve="multiple" />
-                  <node concept="3clFbT" id="d_" role="37wK5m" />
+                  <node concept="3clFbT" id="dA" role="37wK5m" />
                 </node>
               </node>
-              <node concept="liA8E" id="dj" role="2OqNvi">
+              <node concept="liA8E" id="dk" role="2OqNvi">
                 <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2$AggregationLinkBuilder.origin(java.lang.String)" resolve="origin" />
-                <node concept="Xl_RD" id="dA" role="37wK5m">
+                <node concept="Xl_RD" id="dB" role="37wK5m">
                   <property role="Xl_RC" value="5721587534047265375" />
                 </node>
               </node>
             </node>
-            <node concept="liA8E" id="dh" role="2OqNvi">
+            <node concept="liA8E" id="di" role="2OqNvi">
               <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2$AggregationLinkBuilder.done()" resolve="done" />
             </node>
           </node>
         </node>
         <node concept="3clFbF" id="bX" role="3cqZAp">
-          <node concept="2OqwBi" id="dB" role="3clFbG">
-            <node concept="2OqwBi" id="dC" role="2Oq$k0">
-              <node concept="2OqwBi" id="dE" role="2Oq$k0">
-                <node concept="2OqwBi" id="dG" role="2Oq$k0">
-                  <node concept="2OqwBi" id="dI" role="2Oq$k0">
-                    <node concept="2OqwBi" id="dK" role="2Oq$k0">
-                      <node concept="2OqwBi" id="dM" role="2Oq$k0">
-                        <node concept="37vLTw" id="dO" role="2Oq$k0">
-                          <ref role="3cqZAo" node="c0" resolve="b" />
+          <node concept="2OqwBi" id="dC" role="3clFbG">
+            <node concept="2OqwBi" id="dD" role="2Oq$k0">
+              <node concept="2OqwBi" id="dF" role="2Oq$k0">
+                <node concept="2OqwBi" id="dH" role="2Oq$k0">
+                  <node concept="2OqwBi" id="dJ" role="2Oq$k0">
+                    <node concept="2OqwBi" id="dL" role="2Oq$k0">
+                      <node concept="2OqwBi" id="dN" role="2Oq$k0">
+                        <node concept="37vLTw" id="dP" role="2Oq$k0">
+                          <ref role="3cqZAo" node="c1" resolve="b" />
                         </node>
-                        <node concept="liA8E" id="dP" role="2OqNvi">
+                        <node concept="liA8E" id="dQ" role="2OqNvi">
                           <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2.aggregate(java.lang.String,long)" resolve="aggregate" />
-                          <node concept="Xl_RD" id="dQ" role="37wK5m">
+                          <node concept="Xl_RD" id="dR" role="37wK5m">
                             <property role="Xl_RC" value="project" />
                           </node>
-                          <node concept="1adDum" id="dR" role="37wK5m">
+                          <node concept="1adDum" id="dS" role="37wK5m">
                             <property role="1adDun" value="0x4f67298c4630c318L" />
                           </node>
                         </node>
                       </node>
-                      <node concept="liA8E" id="dN" role="2OqNvi">
+                      <node concept="liA8E" id="dO" role="2OqNvi">
                         <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2$AggregationLinkBuilder.target(long,long,long)" resolve="target" />
-                        <node concept="1adDum" id="dS" role="37wK5m">
+                        <node concept="1adDum" id="dT" role="37wK5m">
                           <property role="1adDun" value="0xf3061a5392264cc5L" />
                         </node>
-                        <node concept="1adDum" id="dT" role="37wK5m">
+                        <node concept="1adDum" id="dU" role="37wK5m">
                           <property role="1adDun" value="0xa443f952ceaf5816L" />
                         </node>
-                        <node concept="1adDum" id="dU" role="37wK5m">
+                        <node concept="1adDum" id="dV" role="37wK5m">
                           <property role="1adDun" value="0xf8c37f506fL" />
                         </node>
                       </node>
                     </node>
-                    <node concept="liA8E" id="dL" role="2OqNvi">
+                    <node concept="liA8E" id="dM" role="2OqNvi">
                       <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2$AggregationLinkBuilder.optional(boolean)" resolve="optional" />
-                      <node concept="3clFbT" id="dV" role="37wK5m">
+                      <node concept="3clFbT" id="dW" role="37wK5m">
                         <property role="3clFbU" value="true" />
                       </node>
                     </node>
                   </node>
-                  <node concept="liA8E" id="dJ" role="2OqNvi">
+                  <node concept="liA8E" id="dK" role="2OqNvi">
                     <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2$AggregationLinkBuilder.ordered(boolean)" resolve="ordered" />
-                    <node concept="3clFbT" id="dW" role="37wK5m">
+                    <node concept="3clFbT" id="dX" role="37wK5m">
                       <property role="3clFbU" value="true" />
                     </node>
                   </node>
                 </node>
-                <node concept="liA8E" id="dH" role="2OqNvi">
+                <node concept="liA8E" id="dI" role="2OqNvi">
                   <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2$AggregationLinkBuilder.multiple(boolean)" resolve="multiple" />
-                  <node concept="3clFbT" id="dX" role="37wK5m" />
+                  <node concept="3clFbT" id="dY" role="37wK5m" />
                 </node>
               </node>
-              <node concept="liA8E" id="dF" role="2OqNvi">
+              <node concept="liA8E" id="dG" role="2OqNvi">
                 <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2$AggregationLinkBuilder.origin(java.lang.String)" resolve="origin" />
-                <node concept="Xl_RD" id="dY" role="37wK5m">
+                <node concept="Xl_RD" id="dZ" role="37wK5m">
                   <property role="Xl_RC" value="5721587534047265560" />
                 </node>
               </node>
             </node>
-            <node concept="liA8E" id="dD" role="2OqNvi">
+            <node concept="liA8E" id="dE" role="2OqNvi">
               <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2$AggregationLinkBuilder.done()" resolve="done" />
             </node>
           </node>
         </node>
         <node concept="3clFbF" id="bY" role="3cqZAp">
-          <node concept="2OqwBi" id="dZ" role="3clFbG">
-            <node concept="37vLTw" id="e0" role="2Oq$k0">
-              <ref role="3cqZAo" node="c0" resolve="b" />
+          <node concept="2OqwBi" id="e0" role="3clFbG">
+            <node concept="2OqwBi" id="e1" role="2Oq$k0">
+              <node concept="2OqwBi" id="e3" role="2Oq$k0">
+                <node concept="2OqwBi" id="e5" role="2Oq$k0">
+                  <node concept="2OqwBi" id="e7" role="2Oq$k0">
+                    <node concept="2OqwBi" id="e9" role="2Oq$k0">
+                      <node concept="2OqwBi" id="eb" role="2Oq$k0">
+                        <node concept="37vLTw" id="ed" role="2Oq$k0">
+                          <ref role="3cqZAo" node="c1" resolve="b" />
+                        </node>
+                        <node concept="liA8E" id="ee" role="2OqNvi">
+                          <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2.aggregate(java.lang.String,long)" resolve="aggregate" />
+                          <node concept="Xl_RD" id="ef" role="37wK5m">
+                            <property role="Xl_RC" value="hint" />
+                          </node>
+                          <node concept="1adDum" id="eg" role="37wK5m">
+                            <property role="1adDun" value="0x1d19c0e87d9d67c2L" />
+                          </node>
+                        </node>
+                      </node>
+                      <node concept="liA8E" id="ec" role="2OqNvi">
+                        <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2$AggregationLinkBuilder.target(long,long,long)" resolve="target" />
+                        <node concept="1adDum" id="eh" role="37wK5m">
+                          <property role="1adDun" value="0xf3061a5392264cc5L" />
+                        </node>
+                        <node concept="1adDum" id="ei" role="37wK5m">
+                          <property role="1adDun" value="0xa443f952ceaf5816L" />
+                        </node>
+                        <node concept="1adDum" id="ej" role="37wK5m">
+                          <property role="1adDun" value="0xf8c37f506fL" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="liA8E" id="ea" role="2OqNvi">
+                      <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2$AggregationLinkBuilder.optional(boolean)" resolve="optional" />
+                      <node concept="3clFbT" id="ek" role="37wK5m">
+                        <property role="3clFbU" value="true" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="liA8E" id="e8" role="2OqNvi">
+                    <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2$AggregationLinkBuilder.ordered(boolean)" resolve="ordered" />
+                    <node concept="3clFbT" id="el" role="37wK5m">
+                      <property role="3clFbU" value="true" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="liA8E" id="e6" role="2OqNvi">
+                  <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2$AggregationLinkBuilder.multiple(boolean)" resolve="multiple" />
+                  <node concept="3clFbT" id="em" role="37wK5m" />
+                </node>
+              </node>
+              <node concept="liA8E" id="e4" role="2OqNvi">
+                <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2$AggregationLinkBuilder.origin(java.lang.String)" resolve="origin" />
+                <node concept="Xl_RD" id="en" role="37wK5m">
+                  <property role="Xl_RC" value="2096919206290089922" />
+                </node>
+              </node>
             </node>
-            <node concept="liA8E" id="e1" role="2OqNvi">
+            <node concept="liA8E" id="e2" role="2OqNvi">
+              <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2$AggregationLinkBuilder.done()" resolve="done" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbF" id="bZ" role="3cqZAp">
+          <node concept="2OqwBi" id="eo" role="3clFbG">
+            <node concept="37vLTw" id="ep" role="2Oq$k0">
+              <ref role="3cqZAo" node="c1" resolve="b" />
+            </node>
+            <node concept="liA8E" id="eq" role="2OqNvi">
               <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2.alias(java.lang.String)" resolve="alias" />
-              <node concept="Xl_RD" id="e2" role="37wK5m">
+              <node concept="Xl_RD" id="er" role="37wK5m">
                 <property role="Xl_RC" value="message" />
               </node>
             </node>
           </node>
         </node>
-        <node concept="3cpWs6" id="bZ" role="3cqZAp">
-          <node concept="2OqwBi" id="e3" role="3cqZAk">
-            <node concept="37vLTw" id="e4" role="2Oq$k0">
-              <ref role="3cqZAo" node="c0" resolve="b" />
+        <node concept="3cpWs6" id="c0" role="3cqZAp">
+          <node concept="2OqwBi" id="es" role="3cqZAk">
+            <node concept="37vLTw" id="et" role="2Oq$k0">
+              <ref role="3cqZAo" node="c1" resolve="b" />
             </node>
-            <node concept="liA8E" id="e5" role="2OqNvi">
+            <node concept="liA8E" id="eu" role="2OqNvi">
               <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2.create()" resolve="create" />
             </node>
           </node>
@@ -2799,218 +2864,218 @@
       <property role="DiZV1" value="false" />
       <property role="2aFKle" value="false" />
       <property role="TrG5h" value="createDescriptorForPrintStatement" />
-      <node concept="3clFbS" id="e6" role="3clF47">
-        <node concept="3cpWs8" id="e9" role="3cqZAp">
-          <node concept="3cpWsn" id="ej" role="3cpWs9">
+      <node concept="3clFbS" id="ev" role="3clF47">
+        <node concept="3cpWs8" id="ey" role="3cqZAp">
+          <node concept="3cpWsn" id="eG" role="3cpWs9">
             <property role="TrG5h" value="b" />
-            <node concept="3uibUv" id="ek" role="1tU5fm">
+            <node concept="3uibUv" id="eH" role="1tU5fm">
               <ref role="3uigEE" to="bzg8:~ConceptDescriptorBuilder2" resolve="ConceptDescriptorBuilder2" />
             </node>
-            <node concept="2ShNRf" id="el" role="33vP2m">
-              <node concept="1pGfFk" id="em" role="2ShVmc">
+            <node concept="2ShNRf" id="eI" role="33vP2m">
+              <node concept="1pGfFk" id="eJ" role="2ShVmc">
                 <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2.&lt;init&gt;(java.lang.String,java.lang.String,long,long,long)" resolve="ConceptDescriptorBuilder2" />
-                <node concept="Xl_RD" id="en" role="37wK5m">
+                <node concept="Xl_RD" id="eK" role="37wK5m">
                   <property role="Xl_RC" value="jetbrains.mps.baseLanguage.logging" />
                 </node>
-                <node concept="Xl_RD" id="eo" role="37wK5m">
+                <node concept="Xl_RD" id="eL" role="37wK5m">
                   <property role="Xl_RC" value="PrintStatement" />
                 </node>
-                <node concept="1adDum" id="ep" role="37wK5m">
+                <node concept="1adDum" id="eM" role="37wK5m">
                   <property role="1adDun" value="0x760a0a8ceabb4521L" />
                 </node>
-                <node concept="1adDum" id="eq" role="37wK5m">
+                <node concept="1adDum" id="eN" role="37wK5m">
                   <property role="1adDun" value="0x8bfd65db761a9ba3L" />
                 </node>
-                <node concept="1adDum" id="er" role="37wK5m">
+                <node concept="1adDum" id="eO" role="37wK5m">
                   <property role="1adDun" value="0x1100a2cc320L" />
                 </node>
               </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="ea" role="3cqZAp">
-          <node concept="2OqwBi" id="es" role="3clFbG">
-            <node concept="37vLTw" id="et" role="2Oq$k0">
-              <ref role="3cqZAo" node="ej" resolve="b" />
+        <node concept="3clFbF" id="ez" role="3cqZAp">
+          <node concept="2OqwBi" id="eP" role="3clFbG">
+            <node concept="37vLTw" id="eQ" role="2Oq$k0">
+              <ref role="3cqZAo" node="eG" resolve="b" />
             </node>
-            <node concept="liA8E" id="eu" role="2OqNvi">
+            <node concept="liA8E" id="eR" role="2OqNvi">
               <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2.class_(boolean,boolean,boolean)" resolve="class_" />
-              <node concept="3clFbT" id="ev" role="37wK5m" />
-              <node concept="3clFbT" id="ew" role="37wK5m" />
-              <node concept="3clFbT" id="ex" role="37wK5m" />
+              <node concept="3clFbT" id="eS" role="37wK5m" />
+              <node concept="3clFbT" id="eT" role="37wK5m" />
+              <node concept="3clFbT" id="eU" role="37wK5m" />
             </node>
           </node>
         </node>
-        <node concept="3SKdUt" id="eb" role="3cqZAp">
-          <node concept="1PaTwC" id="ey" role="1aUNEU">
-            <node concept="3oM_SD" id="ez" role="1PaTwD">
+        <node concept="3SKdUt" id="e$" role="3cqZAp">
+          <node concept="1PaTwC" id="eV" role="1aUNEU">
+            <node concept="3oM_SD" id="eW" role="1PaTwD">
               <property role="3oM_SC" value="extends:" />
             </node>
-            <node concept="3oM_SD" id="e$" role="1PaTwD">
+            <node concept="3oM_SD" id="eX" role="1PaTwD">
               <property role="3oM_SC" value="jetbrains.mps.baseLanguage.structure.Statement" />
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="ec" role="3cqZAp">
-          <node concept="15s5l7" id="e_" role="lGtFl">
+        <node concept="3clFbF" id="e_" role="3cqZAp">
+          <node concept="15s5l7" id="eY" role="lGtFl">
             <property role="1eyWvh" value="FLAVOUR_ISSUE_KIND=&quot;typesystem (typesystem)&quot;;FLAVOUR_MESSAGE=&quot;Error: wrong number of parameters&quot;;FLAVOUR_RULE_ID=&quot;[r:00000000-0000-4000-0000-011c895902c5(jetbrains.mps.baseLanguage.typesystem)/1219948518456]&quot;;" />
             <property role="huDt6" value="Error: wrong number of parameters" />
           </node>
-          <node concept="2OqwBi" id="eA" role="3clFbG">
-            <node concept="37vLTw" id="eB" role="2Oq$k0">
-              <ref role="3cqZAo" node="ej" resolve="b" />
+          <node concept="2OqwBi" id="eZ" role="3clFbG">
+            <node concept="37vLTw" id="f0" role="2Oq$k0">
+              <ref role="3cqZAo" node="eG" resolve="b" />
             </node>
-            <node concept="liA8E" id="eC" role="2OqNvi">
+            <node concept="liA8E" id="f1" role="2OqNvi">
               <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2.super_(long,long,long)" resolve="super_" />
-              <node concept="1adDum" id="eD" role="37wK5m">
+              <node concept="1adDum" id="f2" role="37wK5m">
                 <property role="1adDun" value="0xf3061a5392264cc5L" />
               </node>
-              <node concept="1adDum" id="eE" role="37wK5m">
+              <node concept="1adDum" id="f3" role="37wK5m">
                 <property role="1adDun" value="0xa443f952ceaf5816L" />
               </node>
-              <node concept="1adDum" id="eF" role="37wK5m">
+              <node concept="1adDum" id="f4" role="37wK5m">
                 <property role="1adDun" value="0xf8cc56b215L" />
               </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="ed" role="3cqZAp">
-          <node concept="2OqwBi" id="eG" role="3clFbG">
-            <node concept="37vLTw" id="eH" role="2Oq$k0">
-              <ref role="3cqZAo" node="ej" resolve="b" />
+        <node concept="3clFbF" id="eA" role="3cqZAp">
+          <node concept="2OqwBi" id="f5" role="3clFbG">
+            <node concept="37vLTw" id="f6" role="2Oq$k0">
+              <ref role="3cqZAo" node="eG" resolve="b" />
             </node>
-            <node concept="liA8E" id="eI" role="2OqNvi">
+            <node concept="liA8E" id="f7" role="2OqNvi">
               <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2.origin(java.lang.String)" resolve="origin" />
-              <node concept="Xl_RD" id="eJ" role="37wK5m">
+              <node concept="Xl_RD" id="f8" role="37wK5m">
                 <property role="Xl_RC" value="r:00000000-0000-4000-0000-011c8959057f(jetbrains.mps.baseLanguage.logging.structure)/1168401810208" />
               </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="ee" role="3cqZAp">
-          <node concept="2OqwBi" id="eK" role="3clFbG">
-            <node concept="37vLTw" id="eL" role="2Oq$k0">
-              <ref role="3cqZAo" node="ej" resolve="b" />
+        <node concept="3clFbF" id="eB" role="3cqZAp">
+          <node concept="2OqwBi" id="f9" role="3clFbG">
+            <node concept="37vLTw" id="fa" role="2Oq$k0">
+              <ref role="3cqZAo" node="eG" resolve="b" />
             </node>
-            <node concept="liA8E" id="eM" role="2OqNvi">
+            <node concept="liA8E" id="fb" role="2OqNvi">
               <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2.version(int)" resolve="version" />
-              <node concept="3cmrfG" id="eN" role="37wK5m">
+              <node concept="3cmrfG" id="fc" role="37wK5m">
                 <property role="3cmrfH" value="3" />
               </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="ef" role="3cqZAp">
-          <node concept="2OqwBi" id="eO" role="3clFbG">
-            <node concept="2OqwBi" id="eP" role="2Oq$k0">
-              <node concept="2OqwBi" id="eR" role="2Oq$k0">
-                <node concept="2OqwBi" id="eT" role="2Oq$k0">
-                  <node concept="2OqwBi" id="eV" role="2Oq$k0">
-                    <node concept="2OqwBi" id="eX" role="2Oq$k0">
-                      <node concept="2OqwBi" id="eZ" role="2Oq$k0">
-                        <node concept="37vLTw" id="f1" role="2Oq$k0">
-                          <ref role="3cqZAo" node="ej" resolve="b" />
+        <node concept="3clFbF" id="eC" role="3cqZAp">
+          <node concept="2OqwBi" id="fd" role="3clFbG">
+            <node concept="2OqwBi" id="fe" role="2Oq$k0">
+              <node concept="2OqwBi" id="fg" role="2Oq$k0">
+                <node concept="2OqwBi" id="fi" role="2Oq$k0">
+                  <node concept="2OqwBi" id="fk" role="2Oq$k0">
+                    <node concept="2OqwBi" id="fm" role="2Oq$k0">
+                      <node concept="2OqwBi" id="fo" role="2Oq$k0">
+                        <node concept="37vLTw" id="fq" role="2Oq$k0">
+                          <ref role="3cqZAo" node="eG" resolve="b" />
                         </node>
-                        <node concept="liA8E" id="f2" role="2OqNvi">
+                        <node concept="liA8E" id="fr" role="2OqNvi">
                           <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2.aggregate(java.lang.String,long)" resolve="aggregate" />
-                          <node concept="Xl_RD" id="f3" role="37wK5m">
+                          <node concept="Xl_RD" id="fs" role="37wK5m">
                             <property role="Xl_RC" value="textExpression" />
                           </node>
-                          <node concept="1adDum" id="f4" role="37wK5m">
+                          <node concept="1adDum" id="ft" role="37wK5m">
                             <property role="1adDun" value="0x1100a2d9863L" />
                           </node>
                         </node>
                       </node>
-                      <node concept="liA8E" id="f0" role="2OqNvi">
+                      <node concept="liA8E" id="fp" role="2OqNvi">
                         <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2$AggregationLinkBuilder.target(long,long,long)" resolve="target" />
-                        <node concept="1adDum" id="f5" role="37wK5m">
+                        <node concept="1adDum" id="fu" role="37wK5m">
                           <property role="1adDun" value="0xf3061a5392264cc5L" />
                         </node>
-                        <node concept="1adDum" id="f6" role="37wK5m">
+                        <node concept="1adDum" id="fv" role="37wK5m">
                           <property role="1adDun" value="0xa443f952ceaf5816L" />
                         </node>
-                        <node concept="1adDum" id="f7" role="37wK5m">
+                        <node concept="1adDum" id="fw" role="37wK5m">
                           <property role="1adDun" value="0xf8c37f506fL" />
                         </node>
                       </node>
                     </node>
-                    <node concept="liA8E" id="eY" role="2OqNvi">
+                    <node concept="liA8E" id="fn" role="2OqNvi">
                       <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2$AggregationLinkBuilder.optional(boolean)" resolve="optional" />
-                      <node concept="3clFbT" id="f8" role="37wK5m">
+                      <node concept="3clFbT" id="fx" role="37wK5m">
                         <property role="3clFbU" value="true" />
                       </node>
                     </node>
                   </node>
-                  <node concept="liA8E" id="eW" role="2OqNvi">
+                  <node concept="liA8E" id="fl" role="2OqNvi">
                     <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2$AggregationLinkBuilder.ordered(boolean)" resolve="ordered" />
-                    <node concept="3clFbT" id="f9" role="37wK5m">
+                    <node concept="3clFbT" id="fy" role="37wK5m">
                       <property role="3clFbU" value="true" />
                     </node>
                   </node>
                 </node>
-                <node concept="liA8E" id="eU" role="2OqNvi">
+                <node concept="liA8E" id="fj" role="2OqNvi">
                   <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2$AggregationLinkBuilder.multiple(boolean)" resolve="multiple" />
-                  <node concept="3clFbT" id="fa" role="37wK5m">
+                  <node concept="3clFbT" id="fz" role="37wK5m">
                     <property role="3clFbU" value="true" />
                   </node>
                 </node>
               </node>
-              <node concept="liA8E" id="eS" role="2OqNvi">
+              <node concept="liA8E" id="fh" role="2OqNvi">
                 <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2$AggregationLinkBuilder.origin(java.lang.String)" resolve="origin" />
-                <node concept="Xl_RD" id="fb" role="37wK5m">
+                <node concept="Xl_RD" id="f$" role="37wK5m">
                   <property role="Xl_RC" value="1168401864803" />
                 </node>
               </node>
             </node>
-            <node concept="liA8E" id="eQ" role="2OqNvi">
+            <node concept="liA8E" id="ff" role="2OqNvi">
               <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2$AggregationLinkBuilder.done()" resolve="done" />
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="eg" role="3cqZAp">
-          <node concept="2OqwBi" id="fc" role="3clFbG">
-            <node concept="37vLTw" id="fd" role="2Oq$k0">
-              <ref role="3cqZAo" node="ej" resolve="b" />
+        <node concept="3clFbF" id="eD" role="3cqZAp">
+          <node concept="2OqwBi" id="f_" role="3clFbG">
+            <node concept="37vLTw" id="fA" role="2Oq$k0">
+              <ref role="3cqZAo" node="eG" resolve="b" />
             </node>
-            <node concept="liA8E" id="fe" role="2OqNvi">
+            <node concept="liA8E" id="fB" role="2OqNvi">
               <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2.kind(jetbrains.mps.smodel.runtime.ConceptKind,jetbrains.mps.smodel.runtime.StaticScope)" resolve="kind" />
-              <node concept="Rm8GO" id="ff" role="37wK5m">
+              <node concept="Rm8GO" id="fC" role="37wK5m">
                 <ref role="1Px2BO" to="ze1i:~ConceptKind" resolve="ConceptKind" />
                 <ref role="Rm8GQ" to="ze1i:~ConceptKind.NORMAL" resolve="NORMAL" />
               </node>
-              <node concept="Rm8GO" id="fg" role="37wK5m">
+              <node concept="Rm8GO" id="fD" role="37wK5m">
                 <ref role="1Px2BO" to="ze1i:~StaticScope" resolve="StaticScope" />
                 <ref role="Rm8GQ" to="ze1i:~StaticScope.NONE" resolve="NONE" />
               </node>
             </node>
           </node>
         </node>
-        <node concept="3clFbF" id="eh" role="3cqZAp">
-          <node concept="2OqwBi" id="fh" role="3clFbG">
-            <node concept="37vLTw" id="fi" role="2Oq$k0">
-              <ref role="3cqZAo" node="ej" resolve="b" />
+        <node concept="3clFbF" id="eE" role="3cqZAp">
+          <node concept="2OqwBi" id="fE" role="3clFbG">
+            <node concept="37vLTw" id="fF" role="2Oq$k0">
+              <ref role="3cqZAo" node="eG" resolve="b" />
             </node>
-            <node concept="liA8E" id="fj" role="2OqNvi">
+            <node concept="liA8E" id="fG" role="2OqNvi">
               <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2.alias(java.lang.String)" resolve="alias" />
-              <node concept="Xl_RD" id="fk" role="37wK5m">
+              <node concept="Xl_RD" id="fH" role="37wK5m">
                 <property role="Xl_RC" value="print" />
               </node>
             </node>
           </node>
         </node>
-        <node concept="3cpWs6" id="ei" role="3cqZAp">
-          <node concept="2OqwBi" id="fl" role="3cqZAk">
-            <node concept="37vLTw" id="fm" role="2Oq$k0">
-              <ref role="3cqZAo" node="ej" resolve="b" />
+        <node concept="3cpWs6" id="eF" role="3cqZAp">
+          <node concept="2OqwBi" id="fI" role="3cqZAk">
+            <node concept="37vLTw" id="fJ" role="2Oq$k0">
+              <ref role="3cqZAo" node="eG" resolve="b" />
             </node>
-            <node concept="liA8E" id="fn" role="2OqNvi">
+            <node concept="liA8E" id="fK" role="2OqNvi">
               <ref role="37wK5l" to="bzg8:~ConceptDescriptorBuilder2.create()" resolve="create" />
             </node>
           </node>
         </node>
       </node>
-      <node concept="3Tm6S6" id="e7" role="1B3o_S" />
-      <node concept="3uibUv" id="e8" role="3clF45">
+      <node concept="3Tm6S6" id="ew" role="1B3o_S" />
+      <node concept="3uibUv" id="ex" role="3clF45">
         <ref role="3uigEE" to="ze1i:~ConceptDescriptor" resolve="ConceptDescriptor" />
       </node>
     </node>

--- a/languages/baseLanguage/logging/source_gen/jetbrains/mps/baseLanguage/logging/structure/trace.info
+++ b/languages/baseLanguage/logging/source_gen/jetbrains/mps/baseLanguage/logging/structure/trace.info
@@ -20,7 +20,7 @@
       <unit at="10,0,34,0" name="jetbrains.mps.baseLanguage.logging.structure.LanguageConceptSwitch" />
     </file>
     <file name="StructureAspectDescriptor.java">
-      <unit at="19,0,118,0" name="jetbrains.mps.baseLanguage.logging.structure.StructureAspectDescriptor" />
+      <unit at="19,0,119,0" name="jetbrains.mps.baseLanguage.logging.structure.StructureAspectDescriptor" />
     </file>
   </root>
   <root nodeRef="r:00000000-0000-4000-0000-011c8959057f(jetbrains.mps.baseLanguage.logging.structure)/1168401810208">
@@ -44,22 +44,22 @@
     <file name="StructureAspectDescriptor.java">
       <node id="1168401810208" at="23,0,24,0" concept="2" trace="myConceptPrintStatement" />
       <node id="1168401810208" at="53,48,54,39" concept="6" />
-      <node id="1168401810208" at="105,72,106,178" concept="5" />
-      <node id="1168401810208" at="106,178,107,34" concept="1" />
-      <node id="1168401810208" at="107,34,108,62" concept="7" />
-      <node id="1168401810208" at="108,62,109,70" concept="1" />
-      <node id="1168401810208" at="109,70,110,115" concept="1" />
-      <node id="1168401810208" at="110,115,111,17" concept="1" />
-      <node id="1168401864803" at="111,17,112,189" concept="1" />
-      <node id="1168401810208" at="112,189,113,49" concept="1" />
-      <node id="1168401810208" at="113,49,114,21" concept="1" />
-      <node id="1168401810208" at="114,21,115,22" concept="6" />
-      <node id="1168401810208" at="105,0,117,0" concept="9" trace="createDescriptorForPrintStatement#()Ljetbrains/mps/smodel/runtime/ConceptDescriptor;" />
+      <node id="1168401810208" at="106,72,107,178" concept="5" />
+      <node id="1168401810208" at="107,178,108,34" concept="1" />
+      <node id="1168401810208" at="108,34,109,62" concept="7" />
+      <node id="1168401810208" at="109,62,110,70" concept="1" />
+      <node id="1168401810208" at="110,70,111,115" concept="1" />
+      <node id="1168401810208" at="111,115,112,17" concept="1" />
+      <node id="1168401864803" at="112,17,113,189" concept="1" />
+      <node id="1168401810208" at="113,189,114,49" concept="1" />
+      <node id="1168401810208" at="114,49,115,21" concept="1" />
+      <node id="1168401810208" at="115,21,116,22" concept="6" />
+      <node id="1168401810208" at="106,0,118,0" concept="9" trace="createDescriptorForPrintStatement#()Ljetbrains/mps/smodel/runtime/ConceptDescriptor;" />
       <scope id="1168401810208" at="53,48,54,39" />
-      <scope id="1168401810208" at="105,72,115,22">
+      <scope id="1168401810208" at="106,72,116,22">
         <var name="b" id="1168401810208" />
       </scope>
-      <scope id="1168401810208" at="105,0,117,0" />
+      <scope id="1168401810208" at="106,0,118,0" />
     </file>
   </root>
   <root nodeRef="r:00000000-0000-4000-0000-011c8959057f(jetbrains.mps.baseLanguage.logging.structure)/2034914114981261497">
@@ -193,14 +193,15 @@
       <node id="5721587534047265374" at="98,174,99,195" concept="1" />
       <node id="5721587534047265375" at="99,195,100,196" concept="1" />
       <node id="5721587534047265560" at="100,196,101,194" concept="1" />
-      <node id="6332851714983831325" at="101,194,102,23" concept="1" />
-      <node id="6332851714983831325" at="102,23,103,22" concept="6" />
-      <node id="6332851714983831325" at="90,0,105,0" concept="9" trace="createDescriptorForMsgStatement#()Ljetbrains/mps/smodel/runtime/ConceptDescriptor;" />
+      <node id="2096919206290089922" at="101,194,102,191" concept="1" />
+      <node id="6332851714983831325" at="102,191,103,23" concept="1" />
+      <node id="6332851714983831325" at="103,23,104,22" concept="6" />
+      <node id="6332851714983831325" at="90,0,106,0" concept="9" trace="createDescriptorForMsgStatement#()Ljetbrains/mps/smodel/runtime/ConceptDescriptor;" />
       <scope id="6332851714983831325" at="51,46,52,37" />
-      <scope id="6332851714983831325" at="90,70,103,22">
+      <scope id="6332851714983831325" at="90,70,104,22">
         <var name="b" id="6332851714983831325" />
       </scope>
-      <scope id="6332851714983831325" at="90,0,105,0" />
+      <scope id="6332851714983831325" at="90,0,106,0" />
     </file>
   </root>
   <root nodeRef="r:00000000-0000-4000-0000-011c8959057f(jetbrains.mps.baseLanguage.logging.structure)/6332851714983849654">

--- a/languages/baseLanguage/unitTest/jetbrains.mps.baseLanguage.unitTest.libs.msd
+++ b/languages/baseLanguage/unitTest/jetbrains.mps.baseLanguage.unitTest.libs.msd
@@ -22,12 +22,7 @@
   <dependencies>
     <dependency reexport="false">6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)</dependency>
   </dependencies>
-  <languageVersions>
-    <language slang="l:f3061a53-9226-4cc5-a443-f952ceaf5816:jetbrains.mps.baseLanguage" version="12" />
-    <language slang="l:f2801650-65d5-424e-bb1b-463a8781b786:jetbrains.mps.baseLanguage.javadoc" version="2" />
-    <language slang="l:ceab5195-25ea-4f22-9b92-103b95ca8c0c:jetbrains.mps.lang.core" version="2" />
-    <language slang="l:9ded098b-ad6a-4657-bfd9-48636cfe8bc3:jetbrains.mps.lang.traceable" version="0" />
-  </languageVersions>
+  <languageVersions />
   <dependencyVersions>
     <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
     <module reference="83f155ff-422c-4b5a-a2f2-b459302dd215(jetbrains.mps.baseLanguage.unitTest.libs)" version="0" />

--- a/languages/languageDesign/generator/test/entity/jetbrains.mps.generator.test.crossmodel.entity.mpl
+++ b/languages/languageDesign/generator/test/entity/jetbrains.mps.generator.test.crossmodel.entity.mpl
@@ -50,6 +50,7 @@
         <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="4d14758c-3ecb-486d-b8c8-ea5beb8ae408(jetbrains.mps.generator.test.crossmodel.entity)" version="0" />
         <module reference="0748f69c-0f19-4fe4-84a5-b51ed82f0548(jetbrains.mps.generator.test.crossmodel.entity#5533782486491461718)" version="0" />
         <module reference="dc1cc948-6f43-4687-90cb-17dd5cb27219(jetbrains.mps.generator.test.crossmodel.property)" version="0" />

--- a/languages/languageDesign/generator/test/inputLang/jetbrains.mps.transformation.test.inputLang.mpl
+++ b/languages/languageDesign/generator/test/inputLang/jetbrains.mps.transformation.test.inputLang.mpl
@@ -56,6 +56,7 @@
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
         <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
         <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />

--- a/languages/languageDesign/generator/test/inputLangGen1/jetbrains.mps.transformation.test.inputLang.generator01.mpst
+++ b/languages/languageDesign/generator/test/inputLangGen1/jetbrains.mps.transformation.test.inputLang.generator01.mpst
@@ -39,6 +39,7 @@
     <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+    <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
     <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
     <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />

--- a/languages/languageDesign/generator/test/inputLangGen2/jetbrains.mps.transformation.test.inputLang.generator02.mpst
+++ b/languages/languageDesign/generator/test/inputLangGen2/jetbrains.mps.transformation.test.inputLang.generator02.mpst
@@ -40,6 +40,7 @@
     <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+    <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
     <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
     <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />

--- a/languages/languageDesign/generator/test/inputLangGen3/jetbrains.mps.transformation.test.inputLang.generator03.mpst
+++ b/languages/languageDesign/generator/test/inputLangGen3/jetbrains.mps.transformation.test.inputLang.generator03.mpst
@@ -40,6 +40,7 @@
     <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+    <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
     <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
     <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />

--- a/languages/languageDesign/generator/test/inputLangGen4/jetbrains.mps.transformation.test.inputLang.generator04.mpst
+++ b/languages/languageDesign/generator/test/inputLangGen4/jetbrains.mps.transformation.test.inputLang.generator04.mpst
@@ -40,6 +40,7 @@
     <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+    <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
     <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
     <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />

--- a/languages/languageDesign/generator/test/inputLangGen5/jetbrains.mps.transformation.test.inputLang.generator05.mpst
+++ b/languages/languageDesign/generator/test/inputLangGen5/jetbrains.mps.transformation.test.inputLang.generator05.mpst
@@ -40,6 +40,7 @@
     <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
     <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
     <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+    <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
     <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
     <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />

--- a/languages/languageDesign/generator/test/outputLang/jetbrains.mps.transformation.test.outputLang.mpl
+++ b/languages/languageDesign/generator/test/outputLang/jetbrains.mps.transformation.test.outputLang.mpl
@@ -54,6 +54,7 @@
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
         <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
         <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />

--- a/languages/languageDesign/generator/test/property/jetbrains.mps.generator.test.crossmodel.property.mpl
+++ b/languages/languageDesign/generator/test/property/jetbrains.mps.generator.test.crossmodel.property.mpl
@@ -50,6 +50,7 @@
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
         <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="dc1cc948-6f43-4687-90cb-17dd5cb27219(jetbrains.mps.generator.test.crossmodel.property)" version="0" />
         <module reference="708caccd-8eb1-451b-a7a7-f8ae5e214206(jetbrains.mps.generator.test.crossmodel.property#5533782486491461721)" version="0" />
@@ -95,6 +96,7 @@
         <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="dc1cc948-6f43-4687-90cb-17dd5cb27219(jetbrains.mps.generator.test.crossmodel.property)" version="0" />
         <module reference="0748f69c-0123-4fe4-84a5-b51ed82f0548(jetbrains.mps.generator.test.crossmodel.property#g2)" version="0" />
         <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />

--- a/languages/languageDesign/make/languages/outlook/jetbrains.mps.make.outlook.mpl
+++ b/languages/languageDesign/make/languages/outlook/jetbrains.mps.make.outlook.mpl
@@ -51,7 +51,10 @@
         <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+        <module reference="4c6a28d1-2c60-478d-b36e-db9b3cbb21fb(closures.runtime)" version="0" />
+        <module reference="9b80526e-f0bf-4992-bdf5-cee39c1833f3(collections.runtime)" version="0" />
         <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="a247e09e-2435-45ba-b8d2-07e93feba96a(jetbrains.mps.baseLanguage.tuples)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />

--- a/languages/languageDesign/traceinfo/testWeavingGenerated.data/jetbrains.mps.traceInfo.testWeavingGenerated.data.mpl
+++ b/languages/languageDesign/traceinfo/testWeavingGenerated.data/jetbrains.mps.traceInfo.testWeavingGenerated.data.mpl
@@ -50,6 +50,7 @@
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
         <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
         <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />

--- a/languages/languageDesign/traceinfo/testWeavingInterpreted.data/jetbrains.mps.traceInfo.testWeavingInterpreted.data.mpl
+++ b/languages/languageDesign/traceinfo/testWeavingInterpreted.data/jetbrains.mps.traceInfo.testWeavingInterpreted.data.mpl
@@ -49,6 +49,7 @@
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
         <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
         <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />

--- a/languages/languageDesign/traceinfo/traceMacro.testlang/jetbrains.mps.traceInfo.tracemacro.testlang.mpl
+++ b/languages/languageDesign/traceinfo/traceMacro.testlang/jetbrains.mps.traceInfo.tracemacro.testlang.mpl
@@ -47,10 +47,13 @@
         <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+        <module reference="4c6a28d1-2c60-478d-b36e-db9b3cbb21fb(closures.runtime)" version="0" />
+        <module reference="9b80526e-f0bf-4992-bdf5-cee39c1833f3(collections.runtime)" version="0" />
         <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
         <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />
         <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
         <module reference="5f9babc9-8d5d-4825-8e61-17b241ee6272(jetbrains.mps.baseLanguage.collections#1151699677197)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
         <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />

--- a/plugins/execution-languages/languages/demo/jetbrains.mps.execution.demo.mpl
+++ b/plugins/execution-languages/languages/demo/jetbrains.mps.execution.demo.mpl
@@ -45,6 +45,7 @@
         <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e6081818-930c-4926-bdef-3537bcc59087(jetbrains.mps.execution.demo)" version="0" />
         <module reference="d7228511-3a75-45bb-824a-f3ff5f183514(jetbrains.mps.execution.demo#823947676949193248)" version="0" />
         <module reference="4caf0310-491e-41f5-8a9b-2006b3a94898(jetbrains.mps.execution.util)" version="0" />

--- a/plugins/mps-devkit/languages/depanalyzer/jetbrains.mps.ide.depanalyzer.msd
+++ b/plugins/mps-devkit/languages/depanalyzer/jetbrains.mps.ide.depanalyzer.msd
@@ -44,6 +44,7 @@
     <module reference="019b622b-0aef-4dd3-86d0-4eef01f3f6bb(jetbrains.mps.ide)" version="0" />
     <module reference="ced50585-a4e7-485d-b9fb-90c532c1f68f(jetbrains.mps.ide.depanalyzer)" version="0" />
     <module reference="25092e07-e655-497c-92fb-558a8e3080ed(jetbrains.mps.ide.ui)" version="0" />
+    <module reference="a1250a4d-c090-42c3-ad7c-d298a3357dd4(jetbrains.mps.make.runtime)" version="0" />
   </dependencyVersions>
 </solution>
 

--- a/plugins/mps-kotlin/solutions/kotlin.tests.editor/models/jetbrains.mps.kotlin.tests.editor.checks@tests.mps
+++ b/plugins/mps-kotlin/solutions/kotlin.tests.editor/models/jetbrains.mps.kotlin.tests.editor.checks@tests.mps
@@ -49,7 +49,7 @@
       <concept id="7358760241248942182" name="jetbrains.mps.kotlin.structure.Comment" flags="ng" index="gXE$l">
         <child id="7358760241248948562" name="lines" index="gXG0x" />
       </concept>
-      <concept id="781120894705658104" name="jetbrains.mps.kotlin.structure.IKotlinFile" flags="ng" index="2_hZ6C">
+      <concept id="781120894705658104" name="jetbrains.mps.kotlin.structure.IKotlinRoot" flags="ng" index="2_hZ6C">
         <child id="2936055411798374534" name="fileAnnotations" index="1XD0Th" />
       </concept>
       <concept id="7138249191285121087" name="jetbrains.mps.kotlin.structure.IVisible" flags="ng" index="2BPcvI">

--- a/plugins/mps-testing/languages/patternTest/jetbrains.mps.lang.pattern.testLang.mpl
+++ b/plugins/mps-testing/languages/patternTest/jetbrains.mps.lang.pattern.testLang.mpl
@@ -65,16 +65,20 @@
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
         <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
         <module reference="920eaa0e-ecca-46bc-bee7-4e5c59213dd6(Testbench)" version="0" />
+        <module reference="4c6a28d1-2c60-478d-b36e-db9b3cbb21fb(closures.runtime)" version="0" />
+        <module reference="9b80526e-f0bf-4992-bdf5-cee39c1833f3(collections.runtime)" version="0" />
         <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
         <module reference="443f4c36-fcf5-4eb6-9500-8d06ed259e3e(jetbrains.mps.baseLanguage.classifiers)" version="0" />
         <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />
         <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="f61473f9-130f-42f6-b98d-6c438812c2f6(jetbrains.mps.baseLanguage.unitTest)" version="0" />
         <module reference="83f155ff-422c-4b5a-a2f2-b459302dd215(jetbrains.mps.baseLanguage.unitTest.libs)" version="0" />
         <module reference="fdaaf35f-8ee3-4c37-b09d-9efaeaaa7a41(jetbrains.mps.core.tool.environment)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
         <module reference="d936855b-48da-4812-a8a0-2bfddd633ac5(jetbrains.mps.lang.behavior.api)" version="0" />
+        <module reference="d936855b-48da-4812-a8a0-2bfddd633ac4(jetbrains.mps.lang.behavior.runtime)" version="0" />
         <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
         <module reference="446c26eb-2b7b-4bf0-9b35-f83fa582753e(jetbrains.mps.lang.modelapi)" version="0" />
         <module reference="d4615e3b-d671-4ba9-af01-2b78369b0ba7(jetbrains.mps.lang.pattern)" version="0" />
@@ -87,6 +91,7 @@
         <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
         <module reference="8585453e-6bfb-4d80-98de-b16074f1d86c(jetbrains.mps.lang.test)" version="0" />
         <module reference="fc4584d6-365c-4ceb-b660-b2c91933024d(jetbrains.mps.lang.test#1210261198005)" version="0" />
+        <module reference="e55e6749-03cb-4ea7-9695-2322bab791c1(jetbrains.mps.lang.test.matcher)" version="0" />
         <module reference="707c4fde-f79a-44b5-b3d7-b5cef8844ccf(jetbrains.mps.lang.test.runtime)" version="0" />
         <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
         <module reference="9a4afe51-f114-4595-b5df-048ce3c596be(jetbrains.mps.runtime)" version="0" />

--- a/samples/_theSimplestLanguage/languages/theSimplestLanguage/jetbrains.mps.samples.theSimplestLanguage.mpl
+++ b/samples/_theSimplestLanguage/languages/theSimplestLanguage/jetbrains.mps.samples.theSimplestLanguage.mpl
@@ -64,6 +64,7 @@
         <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="4caf0310-491e-41f5-8a9b-2006b3a94898(jetbrains.mps.execution.util)" version="0" />
         <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
         <module reference="f8fecd49-3abe-4733-9741-0c637123d219(jetbrains.mps.samples.theSimplestLanguage)" version="0" />

--- a/samples/attributes/languages/attr/jetbrains.mps.samples.attribute.mpl
+++ b/samples/attributes/languages/attr/jetbrains.mps.samples.attribute.mpl
@@ -49,6 +49,7 @@
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
         <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
         <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />

--- a/samples/blReferences/jetbrains.mps.baseLanguage.box/jetbrains.mps.baseLanguage.box.mpl
+++ b/samples/blReferences/jetbrains.mps.baseLanguage.box/jetbrains.mps.baseLanguage.box.mpl
@@ -56,6 +56,7 @@
         <module reference="1c5b433b-3a0b-47c4-bed8-d496b01eb018(jetbrains.mps.baseLanguage.box)" version="0" />
         <module reference="4f46daa5-56b7-49d7-b8b1-de7e2624aa68(jetbrains.mps.baseLanguage.box#01)" version="0" />
         <module reference="194d1782-2e1a-47e7-9530-40a1f8d132aa(jetbrains.mps.baseLanguage.box.runtime)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
         <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />

--- a/samples/blReferences/jetbrains.mps.baseLanguage.date/jetbrains.mps.baseLanguage.date.mpl
+++ b/samples/blReferences/jetbrains.mps.baseLanguage.date/jetbrains.mps.baseLanguage.date.mpl
@@ -58,6 +58,7 @@
         <module reference="4b7c56eb-9347-4ed1-a5d9-938a850b9e1d(jetbrains.mps.baseLanguage.date)" version="0" />
         <module reference="fd1bd93d-5821-45b2-8f81-d3ef8a16a1c8(jetbrains.mps.baseLanguage.date#01)" version="0" />
         <module reference="6541e803-08dc-479c-ab86-dfa9b4e915e3(jetbrains.mps.baseLanguage.date.runtime)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
         <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />

--- a/samples/calculator-tutorial/languages/calculator/jetbrains.mps.calculator.mpl
+++ b/samples/calculator-tutorial/languages/calculator/jetbrains.mps.calculator.mpl
@@ -66,6 +66,7 @@
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
         <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="26b3d6d5-b99a-4ed6-83be-d2ea6f3627a1(jetbrains.mps.calculator)" version="0" />
         <module reference="08449a34-9b3a-444f-ab50-306e3fd12e6d(jetbrains.mps.calculator#1241363159626)" version="0" />

--- a/samples/complexLanguage/languages/complex/jetbrains.mps.samples.complex.mpl
+++ b/samples/complexLanguage/languages/complex/jetbrains.mps.samples.complex.mpl
@@ -54,6 +54,7 @@
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
         <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
         <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />

--- a/samples/crossModelGeneration/languages/jetbrains.mps.samples.Entities/jetbrains.mps.samples.Entities.mpl
+++ b/samples/crossModelGeneration/languages/jetbrains.mps.samples.Entities/jetbrains.mps.samples.Entities.mpl
@@ -52,6 +52,7 @@
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
         <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
         <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />

--- a/samples/customAspect/languages/jetbrains.mps.samples.customAspect.docLanguage/jetbrains.mps.samples.customAspect.documentation.mpl
+++ b/samples/customAspect/languages/jetbrains.mps.samples.customAspect.docLanguage/jetbrains.mps.samples.customAspect.documentation.mpl
@@ -57,11 +57,17 @@
         <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+        <module reference="4c6a28d1-2c60-478d-b36e-db9b3cbb21fb(closures.runtime)" version="0" />
+        <module reference="9b80526e-f0bf-4992-bdf5-cee39c1833f3(collections.runtime)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e45a8b22-94f2-427f-b849-77f254c4eef5(jetbrains.mps.lang.aspect#3274906159125927726)" version="0" />
+        <module reference="d936855b-48da-4812-a8a0-2bfddd633ac5(jetbrains.mps.lang.behavior.api)" version="0" />
+        <module reference="d936855b-48da-4812-a8a0-2bfddd633ac4(jetbrains.mps.lang.behavior.runtime)" version="0" />
         <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
         <module reference="3ac18869-0828-4401-abad-822a47bf83f1(jetbrains.mps.lang.descriptor#9020561928507175817)" version="0" />
         <module reference="86ef8290-12bb-4ca7-947f-093788f263a9(jetbrains.mps.lang.project)" version="0" />
         <module reference="b19b2d23-1869-41e0-9ee6-8eaad9ffcd84(jetbrains.mps.lang.util.order#174635545557533742)" version="0" />
+        <module reference="9a4afe51-f114-4595-b5df-048ce3c596be(jetbrains.mps.runtime)" version="0" />
         <module reference="22916f45-e98f-4433-9c1b-1b382cf5bd8d(jetbrains.mps.samples.customAspect.documentation)" version="0" />
         <module reference="39b6594d-7cca-44f2-a797-b0ceaead0f42(jetbrains.mps.samples.customAspect.documentation#2897519568668508166)" version="0" />
         <module reference="dd209277-71c0-4f07-bfb3-3a07a1dce2ee(jetbrains.mps.samples.customAspect.documentation.runtime)" version="0" />

--- a/samples/customTestCases/languages/jetbrains.mps.samples.CustomTestCases/jetbrains.mps.samples.CustomTestCases.mpl
+++ b/samples/customTestCases/languages/jetbrains.mps.samples.CustomTestCases/jetbrains.mps.samples.CustomTestCases.mpl
@@ -53,6 +53,7 @@
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
         <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="f61473f9-130f-42f6-b98d-6c438812c2f6(jetbrains.mps.baseLanguage.unitTest)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />

--- a/samples/dslbook_example/languages/secretCompartmentLanguage/jetbrains.mps.samples.secretCompartmentLanguage.mpl
+++ b/samples/dslbook_example/languages/secretCompartmentLanguage/jetbrains.mps.samples.secretCompartmentLanguage.mpl
@@ -51,9 +51,11 @@
         <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
         <module reference="1fd846c3-c5f9-4b9e-9ecc-e716f7149f86(Hamcrest)" version="0" />
         <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
+        <module reference="49808fad-9d41-4b96-83fa-9231640f6b2b(JUnit)" version="0" />
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
         <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="f61473f9-130f-42f6-b98d-6c438812c2f6(jetbrains.mps.baseLanguage.unitTest)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />

--- a/samples/financialCalculations/languages/calculator/jetbrains.mps.samples.fincalculator.mpl
+++ b/samples/financialCalculations/languages/calculator/jetbrains.mps.samples.fincalculator.mpl
@@ -71,6 +71,7 @@
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
         <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="4caf0310-491e-41f5-8a9b-2006b3a94898(jetbrains.mps.execution.util)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />

--- a/samples/fixedLengthReader/readerConfigLanguage/jetbrains.mps.samples.readerConfigLanguage.mpl
+++ b/samples/fixedLengthReader/readerConfigLanguage/jetbrains.mps.samples.readerConfigLanguage.mpl
@@ -54,6 +54,7 @@
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
         <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
         <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
@@ -116,6 +117,7 @@
         <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
         <module reference="089e26c5-bfc3-4a60-9953-f68169a4608a(jetbrains.mps.samples.readerConfigLanguage)" version="0" />
         <module reference="ffb71f3a-317f-4241-a93c-321d713ebf82(jetbrains.mps.samples.readerConfigLanguage.xml#1129923281152)" version="0" />

--- a/samples/formulaLanguage/language/jetbrains.mps.samples.formulaLanguage.mpl
+++ b/samples/formulaLanguage/language/jetbrains.mps.samples.formulaLanguage.mpl
@@ -48,6 +48,7 @@
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
         <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="daafa647-f1f7-4b0b-b096-69cd7c8408c0(jetbrains.mps.baseLanguage.regexp)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="9e79e6dc-3005-4fdf-901d-d1d70047ef7b(jetbrains.mps.formulaLanguage#1130266266255)" version="0" />

--- a/samples/generator_demo/languages/demoLang1/jetbrains.mps.samples.generator_demo.demoLang1.mpl
+++ b/samples/generator_demo/languages/demoLang1/jetbrains.mps.samples.generator_demo.demoLang1.mpl
@@ -67,6 +67,7 @@
         <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
         <module reference="772f6dcd-8c0d-48f7-869c-908e036f7c8e(jetbrains.mps.sampleXML)" version="0" />
         <module reference="fae29102-8774-4e55-af5d-93fa67387f38(jetbrains.mps.samples.generator_demo.demoLang1)" version="0" />

--- a/samples/generator_demo/languages/demoLang2/jetbrains.mps.samples.generator_demo.demoLang2.mpl
+++ b/samples/generator_demo/languages/demoLang2/jetbrains.mps.samples.generator_demo.demoLang2.mpl
@@ -67,6 +67,7 @@
         <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
         <module reference="772f6dcd-8c0d-48f7-869c-908e036f7c8e(jetbrains.mps.sampleXML)" version="0" />
         <module reference="ef47f5be-76c4-4166-8925-2b415ec6b840(jetbrains.mps.samples.generator_demo.demoLang2)" version="0" />

--- a/samples/generator_demo/languages/demoLang3/jetbrains.mps.samples.generator_demo.demoLang3.mpl
+++ b/samples/generator_demo/languages/demoLang3/jetbrains.mps.samples.generator_demo.demoLang3.mpl
@@ -69,6 +69,7 @@
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
         <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
         <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />

--- a/samples/generator_demo/languages/demoLang4/jetbrains.mps.samples.generator_demo.demoLang4.mpl
+++ b/samples/generator_demo/languages/demoLang4/jetbrains.mps.samples.generator_demo.demoLang4.mpl
@@ -52,6 +52,7 @@
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
         <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
         <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />

--- a/samples/generator_demo/languages/demoLang5/jetbrains.mps.samples.generator_demo.demoLang5.mpl
+++ b/samples/generator_demo/languages/demoLang5/jetbrains.mps.samples.generator_demo.demoLang5.mpl
@@ -53,6 +53,7 @@
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
         <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
         <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />

--- a/samples/generator_demo/languages/demoLang7/jetbrains.mps.samples.generator_demo.demoLang7.mpl
+++ b/samples/generator_demo/languages/demoLang7/jetbrains.mps.samples.generator_demo.demoLang7.mpl
@@ -53,6 +53,7 @@
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
         <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
         <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />

--- a/samples/highLevelMetaLanguages/languages/jetbrains.mps.samples.highlevel.simpleEditor/jetbrains.mps.samples.highlevel.simpleEditor.mpl
+++ b/samples/highLevelMetaLanguages/languages/jetbrains.mps.samples.highlevel.simpleEditor/jetbrains.mps.samples.highlevel.simpleEditor.mpl
@@ -53,11 +53,20 @@
         <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
         <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+        <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
+        <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+        <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+        <module reference="4c6a28d1-2c60-478d-b36e-db9b3cbb21fb(closures.runtime)" version="0" />
+        <module reference="9b80526e-f0bf-4992-bdf5-cee39c1833f3(collections.runtime)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
+        <module reference="d44dab97-aaac-44cb-9745-8a14db674c03(jetbrains.mps.baseLanguage.tuples.runtime)" version="0" />
         <module reference="d936855b-48da-4812-a8a0-2bfddd633ac5(jetbrains.mps.lang.behavior.api)" version="0" />
+        <module reference="d936855b-48da-4812-a8a0-2bfddd633ac4(jetbrains.mps.lang.behavior.runtime)" version="0" />
         <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
         <module reference="d7eb0a2a-bd50-4576-beae-e4a89db35f20(jetbrains.mps.lang.scopes.runtime)" version="0" />
         <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
+        <module reference="9a4afe51-f114-4595-b5df-048ce3c596be(jetbrains.mps.runtime)" version="0" />
         <module reference="c457c5de-6027-4104-ab9c-a31c5404ae8b(jetbrains.mps.samples.highlevel.simpleEditor)" version="0" />
         <module reference="36e68e29-6c6e-41ae-bea9-93226f68b150(jetbrains.mps.samples.highlevel.simpleEditor#53726815506686314)" version="0" />
         <module reference="d4c493c2-1545-4793-9c9b-7b665892ccde(jetbrains.mps.samples.highlevel.simpleStructure#53726815506686256)" version="0" />

--- a/samples/highLevelMetaLanguages/languages/jetbrains.mps.samples.highlevel.simpleStructure/jetbrains.mps.samples.highlevel.simpleStructure.mpl
+++ b/samples/highLevelMetaLanguages/languages/jetbrains.mps.samples.highlevel.simpleStructure/jetbrains.mps.samples.highlevel.simpleStructure.mpl
@@ -53,6 +53,8 @@
         <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+        <module reference="4c6a28d1-2c60-478d-b36e-db9b3cbb21fb(closures.runtime)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="d936855b-48da-4812-a8a0-2bfddd633ac5(jetbrains.mps.lang.behavior.api)" version="0" />
         <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
         <module reference="d7eb0a2a-bd50-4576-beae-e4a89db35f20(jetbrains.mps.lang.scopes.runtime)" version="0" />

--- a/samples/lambda/languages/lambdaCalculus/jetbrains.mps.samples.lambdaCalculus.mpl
+++ b/samples/lambda/languages/lambdaCalculus/jetbrains.mps.samples.lambdaCalculus.mpl
@@ -74,6 +74,7 @@
         <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
         <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />
         <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="4caf0310-491e-41f5-8a9b-2006b3a94898(jetbrains.mps.execution.util)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />

--- a/samples/languagePatterns/languages/jetbrains.mps.samples.languagePatterns.Basic/jetbrains.mps.samples.languagePatterns.Basic.mpl
+++ b/samples/languagePatterns/languages/jetbrains.mps.samples.languagePatterns.Basic/jetbrains.mps.samples.languagePatterns.Basic.mpl
@@ -53,6 +53,7 @@
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
         <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
         <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />

--- a/samples/lightweightDSL/languages/jetbrains.mps.samples.SwingBuilder/jetbrains.mps.samples.SwingBuilder.mpl
+++ b/samples/lightweightDSL/languages/jetbrains.mps.samples.SwingBuilder/jetbrains.mps.samples.SwingBuilder.mpl
@@ -56,6 +56,7 @@
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
         <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
         <module reference="c7d5b9dd-a05f-4be2-bc73-f2e16994cc67(jetbrains.mps.baseLanguage.lightweightdsl)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="4caf0310-491e-41f5-8a9b-2006b3a94898(jetbrains.mps.execution.util)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />

--- a/samples/math/jetbrains.mps.baseLanguage.math.mpl
+++ b/samples/math/jetbrains.mps.baseLanguage.math.mpl
@@ -59,6 +59,8 @@
         <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+        <module reference="4c6a28d1-2c60-478d-b36e-db9b3cbb21fb(closures.runtime)" version="0" />
+        <module reference="9b80526e-f0bf-4992-bdf5-cee39c1833f3(collections.runtime)" version="0" />
         <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
         <module reference="ed6d7656-532c-4bc2-81d1-af945aeb8280(jetbrains.mps.baseLanguage.blTypes)" version="0" />
         <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />
@@ -67,10 +69,14 @@
         <module reference="3304fc6e-7c6b-401e-a016-b944934bb21f(jetbrains.mps.baseLanguage.math)" version="0" />
         <module reference="a4f54010-f543-4c3d-a263-da72012ed5d5(jetbrains.mps.baseLanguage.math#1235731725718)" version="0" />
         <module reference="b98999bc-8369-4b20-9510-598d4eb5ace6(jetbrains.mps.baseLanguage.math.runtime)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
+        <module reference="d936855b-48da-4812-a8a0-2bfddd633ac5(jetbrains.mps.lang.behavior.api)" version="0" />
+        <module reference="d936855b-48da-4812-a8a0-2bfddd633ac4(jetbrains.mps.lang.behavior.runtime)" version="0" />
         <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
         <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
+        <module reference="9a4afe51-f114-4595-b5df-048ce3c596be(jetbrains.mps.runtime)" version="0" />
       </dependencyVersions>
       <mapping-priorities>
         <mapping-priority-rule kind="strictly_before">

--- a/samples/money/jetbrains.mps.baseLanguage.money.mpl
+++ b/samples/money/jetbrains.mps.baseLanguage.money.mpl
@@ -60,6 +60,7 @@
         <module reference="f43135f9-b833-4685-8d26-ffb6c8215f72(jetbrains.mps.baseLanguage.money)" version="0" />
         <module reference="e7cb62aa-0cf6-4a49-bf95-a592cd1ba5e5(jetbrains.mps.baseLanguage.money#1186668571599)" version="0" />
         <module reference="4df1d09b-d6ae-453e-8622-14c0d6e4c038(jetbrains.mps.baseLanguage.money.runtime)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
         <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />

--- a/samples/robot_Kaja/languages/KajaAndOr/KajaAndOr.mpl
+++ b/samples/robot_Kaja/languages/KajaAndOr/KajaAndOr.mpl
@@ -50,6 +50,7 @@
         <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="4caf0310-491e-41f5-8a9b-2006b3a94898(jetbrains.mps.execution.util)" version="0" />
         <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
         <module reference="5004e7d9-a353-4cb0-960a-68fc804bd95d(jetbrains.mps.samples.JavaKaja)" version="0" />

--- a/samples/robot_Kaja/languages/KajaSceneConstruction/KajaSceneConstruction.mpl
+++ b/samples/robot_Kaja/languages/KajaSceneConstruction/KajaSceneConstruction.mpl
@@ -51,6 +51,7 @@
         <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="4caf0310-491e-41f5-8a9b-2006b3a94898(jetbrains.mps.execution.util)" version="0" />
         <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
         <module reference="5004e7d9-a353-4cb0-960a-68fc804bd95d(jetbrains.mps.samples.JavaKaja)" version="0" />

--- a/samples/robot_Kaja/languages/Kajak/Kajak.mpl
+++ b/samples/robot_Kaja/languages/Kajak/Kajak.mpl
@@ -52,6 +52,7 @@
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
         <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="4caf0310-491e-41f5-8a9b-2006b3a94898(jetbrains.mps.execution.util)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />

--- a/samples/sampleJavaExtensions/languages/Constants/org.jetbrains.mps.samples.Constants.mpl
+++ b/samples/sampleJavaExtensions/languages/Constants/org.jetbrains.mps.samples.Constants.mpl
@@ -53,6 +53,7 @@
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
         <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
         <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />

--- a/samples/sampleJavaExtensions/languages/DecisionTable/org.jetbrains.mps.samples.DecisionTable.mpl
+++ b/samples/sampleJavaExtensions/languages/DecisionTable/org.jetbrains.mps.samples.DecisionTable.mpl
@@ -55,6 +55,7 @@
         <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
         <module reference="86441d7a-e194-42da-81a5-2161ec62a379(MPS.Workbench)" version="0" />
         <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
         <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />

--- a/samples/sampleJavaExtensions/languages/Money/org.jetbrains.mps.samples.Money.mpl
+++ b/samples/sampleJavaExtensions/languages/Money/org.jetbrains.mps.samples.Money.mpl
@@ -54,6 +54,7 @@
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
         <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
         <module reference="985c8c6a-64b4-486d-a91e-7d4112742556(jetbrains.mps.baseLanguage#1129914002933)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
         <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />

--- a/samples/sampleJavaExtensions/languages/ParallelFor/org.jetbrains.mps.samples.ParallelFor.mpl
+++ b/samples/sampleJavaExtensions/languages/ParallelFor/org.jetbrains.mps.samples.ParallelFor.mpl
@@ -52,8 +52,11 @@
         <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+        <module reference="4c6a28d1-2c60-478d-b36e-db9b3cbb21fb(closures.runtime)" version="0" />
+        <module reference="9b80526e-f0bf-4992-bdf5-cee39c1833f3(collections.runtime)" version="0" />
         <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
         <module reference="5f9babc9-8d5d-4825-8e61-17b241ee6272(jetbrains.mps.baseLanguage.collections#1151699677197)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
         <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />

--- a/samples/sampleJavaExtensions/languages/SampleExtensions/org.jetbrains.mps.samples.IfAndUnless.mpl
+++ b/samples/sampleJavaExtensions/languages/SampleExtensions/org.jetbrains.mps.samples.IfAndUnless.mpl
@@ -48,6 +48,7 @@
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
         <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
         <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />

--- a/samples/shapes/languages/jetbrains.mps.samples.Shapes/jetbrains.mps.samples.Shapes.mpl
+++ b/samples/shapes/languages/jetbrains.mps.samples.Shapes/jetbrains.mps.samples.Shapes.mpl
@@ -58,6 +58,7 @@
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
         <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="4caf0310-491e-41f5-8a9b-2006b3a94898(jetbrains.mps.execution.util)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />

--- a/samples/xmlLiterals/languages/xmlLiterals/jetbrains.mps.samples.xmlLiterals.mpl
+++ b/samples/xmlLiterals/languages/xmlLiterals/jetbrains.mps.samples.xmlLiterals.mpl
@@ -68,9 +68,11 @@
         <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+        <module reference="4c6a28d1-2c60-478d-b36e-db9b3cbb21fb(closures.runtime)" version="0" />
         <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
         <module reference="985c8c6a-64b4-486d-a91e-7d4112742556(jetbrains.mps.baseLanguage#1129914002933)" version="0" />
         <module reference="857d0a79-6f44-4f46-84ed-9c5b42632011(jetbrains.mps.baseLanguage.closures#1199623535494)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="479c7a8c-02f9-43b5-9139-d910cb22f298(jetbrains.mps.core.xml)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />

--- a/testbench/modules/testClassLoading/languages/L1/L1.mpl
+++ b/testbench/modules/testClassLoading/languages/L1/L1.mpl
@@ -53,6 +53,7 @@
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
         <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
         <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />

--- a/testbench/modules/testFindUsages/mps.test.findusages.msd
+++ b/testbench/modules/testFindUsages/mps.test.findusages.msd
@@ -51,6 +51,7 @@
     <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
     <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
     <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
+    <module reference="a1250a4d-c090-42c3-ad7c-d298a3357dd4(jetbrains.mps.make.runtime)" version="0" />
     <module reference="9ebe73c6-437b-4a56-95a7-1d7eec081f24(mps.test.findusages)" version="0" />
   </dependencyVersions>
 </solution>

--- a/testbench/testbench.suite/jetbrains.mps.testbench.suite.mpl
+++ b/testbench/testbench.suite/jetbrains.mps.testbench.suite.mpl
@@ -52,6 +52,7 @@
         <module reference="49808fad-9d41-4b96-83fa-9231640f6b2b(JUnit)" version="0" />
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
         <module reference="e9000334-f5e2-4a2f-a0fc-9afd1d31e048(jetbrains.mps.testbench)" version="0" />
         <module reference="d3c5a46f-b8c2-47db-ad0a-30b8f19c2055(jetbrains.mps.testbench.suite)" version="0" />

--- a/testbench/testsolutions/clone.module.test/clone.module.test.msd
+++ b/testbench/testsolutions/clone.module.test/clone.module.test.msd
@@ -46,6 +46,7 @@
     <module reference="bfbdd672-7ff5-403f-af4f-16da5226f34c(jetbrains.mps.findUsages.runtime)" version="0" />
     <module reference="019b622b-0aef-4dd3-86d0-4eef01f3f6bb(jetbrains.mps.ide)" version="0" />
     <module reference="25092e07-e655-497c-92fb-558a8e3080ed(jetbrains.mps.ide.ui)" version="0" />
+    <module reference="a1250a4d-c090-42c3-ad7c-d298a3357dd4(jetbrains.mps.make.runtime)" version="0" />
   </dependencyVersions>
 </solution>
 

--- a/testbench/testsolutions/testlangs/editor.menus.contextAssistant.extension.testLanguage/jetbrains.mps.lang.editor.menus.contextAssistant.testExtendingLanguage.mpl
+++ b/testbench/testsolutions/testlangs/editor.menus.contextAssistant.extension.testLanguage/jetbrains.mps.lang.editor.menus.contextAssistant.testExtendingLanguage.mpl
@@ -64,6 +64,7 @@
     <module reference="a9e4c532-c5f5-4bb7-99ef-42abb73bbb70(jetbrains.mps.lang.descriptor.aspects)" version="0" />
     <module reference="d1fa0116-fbd7-44fe-bcc8-e093dfdf9f3c(jetbrains.mps.lang.editor.menus.contextAssistant.testExtendingLanguage)" version="0" />
     <module reference="9a629f9a-abc9-4c29-b1b8-db7f349f7fbc(jetbrains.mps.lang.editor.menus.contextAssistant.testLanguage)" version="0" />
+    <module reference="a1250a4d-c090-42c3-ad7c-d298a3357dd4(jetbrains.mps.make.runtime)" version="0" />
   </dependencyVersions>
   <extendedLanguages>
     <extendedLanguage>9a629f9a-abc9-4c29-b1b8-db7f349f7fbc(jetbrains.mps.lang.editor.menus.contextAssistant.testLanguage)</extendedLanguage>

--- a/testbench/testsolutions/testlangs/editor.menus.testMetaLanguage/jetbrains.mps.lang.editor.menus.testMetaLanguage.mpl
+++ b/testbench/testsolutions/testlangs/editor.menus.testMetaLanguage/jetbrains.mps.lang.editor.menus.testMetaLanguage.mpl
@@ -51,14 +51,21 @@
         <module reference="3f233e7f-b8a6-46d2-a57f-795d56775243(Annotations)" version="0" />
         <module reference="6354ebe7-c22a-4a0f-ac54-50b52ab9b065(JDK)" version="0" />
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
+        <module reference="1ed103c3-3aa6-49b7-9c21-6765ee11f224(MPS.Editor)" version="0" />
+        <module reference="498d89d2-c2e9-11e2-ad49-6cf049e62fe5(MPS.IDEA)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
+        <module reference="742f6602-5a2f-4313-aa6e-ae1cd4ffdc61(MPS.Platform)" version="0" />
+        <module reference="4c6a28d1-2c60-478d-b36e-db9b3cbb21fb(closures.runtime)" version="0" />
+        <module reference="9b80526e-f0bf-4992-bdf5-cee39c1833f3(collections.runtime)" version="0" />
         <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
         <module reference="443f4c36-fcf5-4eb6-9500-8d06ed259e3e(jetbrains.mps.baseLanguage.classifiers)" version="0" />
         <module reference="fd392034-7849-419d-9071-12563d152375(jetbrains.mps.baseLanguage.closures)" version="0" />
         <module reference="83888646-71ce-4f1c-9c53-c54016f6ad4f(jetbrains.mps.baseLanguage.collections)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
         <module reference="d936855b-48da-4812-a8a0-2bfddd633ac5(jetbrains.mps.lang.behavior.api)" version="0" />
+        <module reference="d936855b-48da-4812-a8a0-2bfddd633ac4(jetbrains.mps.lang.behavior.runtime)" version="0" />
         <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />
         <module reference="3ac18869-0828-4401-abad-822a47bf83f1(jetbrains.mps.lang.descriptor#9020561928507175817)" version="0" />
         <module reference="18bc6592-03a6-4e29-a83a-7ff23bde13ba(jetbrains.mps.lang.editor)" version="0" />
@@ -70,6 +77,7 @@
         <module reference="7866978e-a0f0-4cc7-81bc-4d213d9375e1(jetbrains.mps.lang.smodel)" version="1" />
         <module reference="c72da2b9-7cce-4447-8389-f407dc1158b7(jetbrains.mps.lang.structure)" version="0" />
         <module reference="9ded098b-ad6a-4657-bfd9-48636cfe8bc3(jetbrains.mps.lang.traceable)" version="0" />
+        <module reference="9a4afe51-f114-4595-b5df-048ce3c596be(jetbrains.mps.runtime)" version="0" />
       </dependencyVersions>
       <mapping-priorities />
     </generator>

--- a/testbench/testsolutions/testlangs/test.lang.with.RT/testLangWithRT.mpl
+++ b/testbench/testsolutions/testlangs/test.lang.with.RT/testLangWithRT.mpl
@@ -48,6 +48,7 @@
         <module reference="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea(MPS.Core)" version="0" />
         <module reference="8865b7a8-5271-43d3-884c-6fd1d9cfdd34(MPS.OpenAPI)" version="0" />
         <module reference="f3061a53-9226-4cc5-a443-f952ceaf5816(jetbrains.mps.baseLanguage)" version="0" />
+        <module reference="52b81ac7-93fd-4e9e-b972-4995882da6d4(jetbrains.mps.baseLanguage.references.runtime)" version="0" />
         <module reference="e39e4a59-8cb6-498e-860e-8fa8361c0d90(jetbrains.mps.baseLanguage.scopes)" version="0" />
         <module reference="2d3c70e9-aab2-4870-8d8d-6036800e4103(jetbrains.mps.kernel)" version="0" />
         <module reference="ceab5195-25ea-4f22-9b92-103b95ca8c0c(jetbrains.mps.lang.core)" version="0" />


### PR DESCRIPTION
Adds an optional `hint` to `jetbrains.mps.baseLanguage.logging.structure.MsgStatement`.
This is especially useful if the hint is an `SNode`, as the user can click on the log message in message pane and jump to the node.

Previously, an instance of `MsgStatement` looked like

```
message info "My LogMessage", <no project>, <no throwable>;
```

Now changed to

```
message info "My LogMessage", <no hintObject>, <no project>, <no throwable>;
```

Hints to `SNode`, `SModel`, or `SModule` are automatically converted to their corresponding references to avoid resource leaks.