### PR TITLE
MpsLoadTask: simplify and fix the MPS home check

### DIFF
--- a/core/tool/ant/source_gen/jetbrains/mps/build/ant/MpsLoadTask.java
+++ b/core/tool/ant/source_gen/jetbrains/mps/build/ant/MpsLoadTask.java
@@ -456,14 +456,7 @@ public class MpsLoadTask extends Task {
   private void checkMpsHome(File mpsHome) {
     // the following code checks mps home is specified correctly
     assert mpsHome != null : "MPS home folder must be specified. Use either mpshome task attribute or mps_home or mps.home Ant property to specify home folder.";
-    boolean containsBuildTxt = false;
-    for (File child : mpsHome.listFiles()) {
-      if (child.getPath().equals("build.txt")) {
-        containsBuildTxt = true;
-        break;
-      }
-    }
-    assert containsBuildTxt : "MPS home folder is the folder where build.txt file is located. Please correct mpshome attribute, mps_home/mps.home property, depending on which was set";
+    assert new File(mpsHome, "build.txt").exists() : "MPS home folder is the folder where build.txt file is located. Please correct mpshome attribute, mps_home/mps.home property, depending on which was set";
 
     outputBuildNumber(mpsHome);
   }


### PR DESCRIPTION
The original code was checking getPath(), which is the full path of a file, against "build.txt", which is just the name.

Also, it isn't necessary to iterate through all the files when we can simply check for existence of a file.