### PR TITLE
Fix relative path calculation in case path contains .. and .

### DIFF
--- a/plugins/mps-build/languages/build/source_gen.caches/jetbrains/mps/build/util/generated
+++ b/plugins/mps-build/languages/build/source_gen.caches/jetbrains/mps/build/util/generated
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<product version="3" modelHash="-a9wj7jborjsckg0xng0ybh5xse2d85x">
+<product version="3" modelHash="-b87jmh4kumpq0gb268kfhw0krkhiaw9">
   <files names="ArtifactLookup.java:Context.java:DependenciesHelper.java:DescendantsScope.java:FDP2.java:FetchDependenciesProcessor.java:FileSetUtil.java:GenerationUtil.java:JavaExportUtil.java:JavaModulesClosure.java:LocalSourcePathArtifact.java:MacroHelper.java:NameUtil.java:PathProvider.java:ProjectDependency.java:RelativePathHelper.java:RequiredDependenciesBuilder.java:ScopeUtil.java:UnpackHelper.java:VisibleArtifacts.java" />
 </product>
 

--- a/plugins/mps-build/languages/build/source_gen/jetbrains/mps/build/util/RelativePathHelper.java
+++ b/plugins/mps-build/languages/build/source_gen/jetbrains/mps/build/util/RelativePathHelper.java
@@ -40,8 +40,8 @@ public class RelativePathHelper {
     }
     // The purpose of the code below is to keep this class purely string/Path-based, without need to access FS or care about file existence.
     try {
-      String[] base = myBasePath.split("/");
-      String[] target = normalized.split("/");
+      String[] base = removeDots(myBasePath.split("/"));
+      String[] target = removeDots(normalized.split("/"));
       int commonLength = 0;
       while (commonLength < target.length && commonLength < base.length && target[commonLength].equals(base[commonLength])) {
         commonLength++;
@@ -76,6 +76,43 @@ public class RelativePathHelper {
     }
   }
 
+  /**
+   * Normalize segments to resolve '.' and '..' according to standard rules.
+   */
+  public static String[] removeDots(String[] segments) {
+    // An array of boolean indicating whether a segment is excluded from the final result
+    boolean[] ignore = new boolean[segments.length];
+    int remainingCount = segments.length;
+
+    for (int i = 0; i < segments.length; i++) {
+      // Ignore each '.'.
+      // In case of '..', ignore it only if it is preceded by a non-ignored segment, ignore that segment as well.
+      if (".".equals(segments[i])) {
+        ignore[i] = true;
+        remainingCount--;
+      } else if ("..".equals(segments[i])) {
+        for (int j = i - 1; j >= 0; j--) {
+          if (!(ignore[j])) {
+            ignore[j] = true;
+            ignore[i] = true;
+            remainingCount -= 2;
+            break;
+          }
+        }
+      }
+    }
+
+    // Return an array of all non-ignored segments.
+    String[] result = new String[remainingCount];
+    int out = 0;
+    for (int in = 0; in < segments.length; in++) {
+      if (!(ignore[in])) {
+        result[out++] = segments[in];
+      }
+    }
+    return result;
+  }
+
   public String makeAbsolute(String shortPath) throws PathException {
     if ((shortPath == null || shortPath.length() == 0)) {
       return myBasePath;
@@ -97,7 +134,6 @@ public class RelativePathHelper {
   public String getBasePath() {
     return myBasePath;
   }
-
 
   /**
    * Translates backslashes in the path, if any, to regular slashed, and appends a trailing one if requested.

--- a/plugins/mps-build/languages/build/source_gen/jetbrains/mps/build/util/trace.info
+++ b/plugins/mps-build/languages/build/source_gen/jetbrains/mps/build/util/trace.info
@@ -2054,9 +2054,9 @@
       <node id="5701816003402893866" at="37,44,38,55" concept="13" />
       <node id="5701816003402917879" at="38,55,39,61" concept="14" />
       <node id="5701816003402911781" at="40,5,41,140" concept="14" />
-      <node id="3913486790549702749" at="42,9,43,44" concept="12" />
-      <node id="3913486790549702756" at="43,44,44,46" concept="12" />
-      <node id="3913486790549802825" at="44,46,45,27" concept="12" />
+      <node id="3913486790549702749" at="42,9,43,56" concept="12" />
+      <node id="3913486790549702756" at="43,56,44,58" concept="12" />
+      <node id="3913486790549802825" at="44,58,45,27" concept="12" />
       <node id="3913486790549802854" at="46,125,47,23" concept="6" />
       <node id="3913486790550416668" at="48,7,49,54" concept="14" />
       <node id="3913486790549802874" at="50,30,51,121" concept="20" />
@@ -2074,20 +2074,38 @@
       <node id="3913486790551121119" at="71,7,72,0" concept="15" />
       <node id="5701816003405642060" at="72,0,73,33" concept="13" />
       <node id="1841835149314774688" at="74,28,75,51" concept="20" />
-      <node id="1841835149314654004" at="80,57,81,24" concept="13" />
-      <node id="1841835149314665826" at="82,5,83,48" concept="6" />
-      <node id="1841835149314665887" at="84,37,85,41" concept="6" />
-      <node id="5701816003402938854" at="86,44,87,41" concept="6" />
-      <node id="1841835149314665709" at="89,9,90,49" concept="12" />
-      <node id="1841835149314774673" at="90,49,91,58" concept="13" />
-      <node id="1841835149314771712" at="92,28,93,51" concept="20" />
-      <node id="1841835149314794597" at="97,31,98,22" concept="13" />
-      <node id="5701816003402821727" at="108,23,109,16" concept="6" />
-      <node id="2617896750899006668" at="110,5,111,35" concept="6" />
-      <node id="2617896750899006694" at="112,84,113,24" concept="6" />
-      <node id="5701816003402864864" at="114,5,115,16" concept="13" />
-      <node id="3913486790550370531" at="120,47,121,21" concept="18" />
-      <node id="1841835149314710252" at="123,59,124,28" concept="18" />
+      <node id="4806869284779942" at="82,56,83,89" concept="14" />
+      <node id="4806869284611158" at="83,89,84,52" concept="12" />
+      <node id="4806869284691507" at="84,52,85,41" concept="12" />
+      <node id="4806869284626281" at="85,41,86,0" concept="15" />
+      <node id="4806869284780423" at="87,47,88,25" concept="14" />
+      <node id="4806869284780888" at="88,25,89,113" concept="14" />
+      <node id="4806869284644807" at="90,36,91,25" concept="6" />
+      <node id="4806869284692616" at="91,25,92,25" concept="6" />
+      <node id="4806869284677290" at="95,29,96,29" concept="6" />
+      <node id="4806869284685064" at="96,29,97,29" concept="6" />
+      <node id="4806869284700139" at="97,29,98,32" concept="6" />
+      <node id="4806869284687955" at="98,32,99,18" concept="2" />
+      <node id="4806869284691057" at="103,5,104,0" concept="15" />
+      <node id="4806869284781837" at="104,0,105,51" concept="14" />
+      <node id="4806869284710009" at="105,51,106,49" concept="12" />
+      <node id="4806869284763155" at="106,49,107,16" concept="12" />
+      <node id="4806869284761590" at="109,26,110,37" concept="6" />
+      <node id="4806869284782429" at="112,5,113,18" concept="13" />
+      <node id="1841835149314654004" at="117,57,118,24" concept="13" />
+      <node id="1841835149314665826" at="119,5,120,48" concept="6" />
+      <node id="1841835149314665887" at="121,37,122,41" concept="6" />
+      <node id="5701816003402938854" at="123,44,124,41" concept="6" />
+      <node id="1841835149314665709" at="126,9,127,49" concept="12" />
+      <node id="1841835149314774673" at="127,49,128,58" concept="13" />
+      <node id="1841835149314771712" at="129,28,130,51" concept="20" />
+      <node id="1841835149314794597" at="134,31,135,22" concept="13" />
+      <node id="5701816003402821727" at="144,23,145,16" concept="6" />
+      <node id="2617896750899006668" at="146,5,147,35" concept="6" />
+      <node id="2617896750899006694" at="148,84,149,24" concept="6" />
+      <node id="5701816003402864864" at="150,5,151,16" concept="13" />
+      <node id="3913486790550370531" at="156,47,157,21" concept="18" />
+      <node id="1841835149314710252" at="159,59,160,28" concept="18" />
       <node id="1841835149314652654" at="12,0,15,0" concept="3" trace="RelativePathHelper#(Ljava/lang/String;)V" />
       <node id="6723782765629118723" at="20,62,23,5" concept="10" />
       <node id="5701816003404084515" at="28,0,31,0" concept="11" trace="isRelative#(Ljava/lang/String;)Z" />
@@ -2097,19 +2115,26 @@
       <node id="3913486790551323676" at="60,41,63,7" concept="8" />
       <node id="3913486790551724881" at="64,43,67,7" concept="8" />
       <node id="3913486790552355283" at="68,94,71,7" concept="10" />
-      <node id="6099797596647572300" at="79,69,82,5" concept="10" />
-      <node id="1841835149314794593" at="97,0,100,0" concept="11" trace="getBasePath#()Ljava/lang/String;" />
-      <node id="5551764612445891453" at="107,69,110,5" concept="10" />
-      <node id="2617896750899006692" at="111,35,114,5" concept="10" />
-      <node id="3913486790550322578" at="120,0,123,0" concept="3" trace="PathException#(Ljava/lang/String;)V" />
-      <node id="1841835149314710239" at="123,0,126,0" concept="3" trace="PathException#(Ljava/lang/Throwable;Ljava/lang/String;)V" />
+      <node id="4806869284772268" at="108,50,111,7" concept="10" />
+      <node id="6099797596647572300" at="116,69,119,5" concept="10" />
+      <node id="1841835149314794593" at="134,0,137,0" concept="11" trace="getBasePath#()Ljava/lang/String;" />
+      <node id="5551764612445891453" at="143,69,146,5" concept="10" />
+      <node id="2617896750899006692" at="147,35,150,5" concept="10" />
+      <node id="3913486790550322578" at="156,0,159,0" concept="3" trace="PathException#(Ljava/lang/String;)V" />
+      <node id="1841835149314710239" at="159,0,162,0" concept="3" trace="PathException#(Ljava/lang/Throwable;Ljava/lang/String;)V" />
       <node id="5701816003402876992" at="36,61,40,5" concept="10" />
       <node id="3913486790555902963" at="52,7,57,7" concept="10" />
-      <node id="1841835149314665853" at="83,48,88,5" concept="10" />
-      <node id="1841835149314771701" at="88,5,94,5" concept="21" />
+      <node id="4806869284743557" at="107,16,112,5" concept="8" />
+      <node id="1841835149314665853" at="120,48,125,5" concept="10" />
+      <node id="4806869284675668" at="94,42,100,11" concept="10" />
+      <node id="1841835149314771701" at="125,5,131,5" concept="21" />
       <node id="6723782765629113508" at="19,0,27,0" concept="17" trace="forModule#(Lorg/jetbrains/mps/openapi/module/SModule;)Ljetbrains/mps/build/util/RelativePathHelper;" />
-      <node id="2617896750899006664" at="107,0,117,0" concept="17" trace="normalizePath#(Ljava/lang/String;Z)Ljava/lang/String;" />
-      <node id="6099797596647572297" at="79,0,96,0" concept="11" trace="makeAbsolute#(Ljava/lang/String;)Ljava/lang/String;" />
+      <node id="4806869284666920" at="93,44,101,9" concept="8" />
+      <node id="2617896750899006664" at="143,0,153,0" concept="17" trace="normalizePath#(Ljava/lang/String;Z)Ljava/lang/String;" />
+      <node id="4806869284639982" at="89,113,102,7" concept="10" />
+      <node id="4806869284626538" at="86,0,103,5" concept="8" />
+      <node id="6099797596647572297" at="116,0,133,0" concept="11" trace="makeAbsolute#(Ljava/lang/String;)Ljava/lang/String;" />
+      <node id="4806869284588728" at="82,0,115,0" concept="17" trace="removeDots#([Ljava/lang/String;)[Ljava/lang/String;" />
       <node id="1841835149314774676" at="41,140,76,5" concept="21" />
       <node id="6099797596647572258" at="32,0,78,0" concept="11" trace="makeRelative#(Ljava/lang/String;)Ljava/lang/String;" />
       <scope id="1841835149314652658" at="12,46,13,47" />
@@ -2122,23 +2147,25 @@
       <scope id="3913486790551724883" at="65,58,66,47" />
       <scope id="3913486790552355285" at="69,111,70,50" />
       <scope id="1841835149314774682" at="74,28,75,51" />
-      <scope id="6099797596647572301" at="80,57,81,24" />
-      <scope id="1841835149314665854" at="84,37,85,41" />
-      <scope id="5701816003402926334" at="86,44,87,41" />
-      <scope id="1841835149314771707" at="92,28,93,51" />
-      <scope id="1841835149314794596" at="97,31,98,22" />
-      <scope id="5551764612445891454" at="108,23,109,16" />
-      <scope id="2617896750899006693" at="112,84,113,24" />
-      <scope id="3913486790550322582" at="120,47,121,21" />
-      <scope id="1841835149314710242" at="123,59,124,28" />
+      <scope id="4806869284772270" at="109,26,110,37" />
+      <scope id="6099797596647572301" at="117,57,118,24" />
+      <scope id="1841835149314665854" at="121,37,122,41" />
+      <scope id="5701816003402926334" at="123,44,124,41" />
+      <scope id="1841835149314771707" at="129,28,130,51" />
+      <scope id="1841835149314794596" at="134,31,135,22" />
+      <scope id="5551764612445891454" at="144,23,145,16" />
+      <scope id="2617896750899006693" at="148,84,149,24" />
+      <scope id="3913486790550322582" at="156,47,157,21" />
+      <scope id="1841835149314710242" at="159,59,160,28" />
       <scope id="5701816003402876994" at="37,44,39,61" />
       <scope id="1841835149314774679" at="74,5,76,5">
         <var name="ex" id="1841835149314774680" />
       </scope>
-      <scope id="1841835149314771702" at="89,9,91,58">
+      <scope id="4806869284639984" at="90,36,92,25" />
+      <scope id="1841835149314771702" at="126,9,128,58">
         <var name="res" id="1841835149314665710" />
       </scope>
-      <scope id="1841835149314771704" at="92,5,94,5">
+      <scope id="1841835149314771704" at="129,5,131,5">
         <var name="ex" id="1841835149314771705" />
       </scope>
       <scope id="1841835149314652654" at="12,0,15,0">
@@ -2154,27 +2181,41 @@
       <scope id="3913486790551724881" at="64,43,67,7">
         <var name="i" id="3913486790551724884" />
       </scope>
-      <scope id="1841835149314794593" at="97,0,100,0" />
-      <scope id="3913486790550322578" at="120,0,123,0">
+      <scope id="4806869284743559" at="108,50,111,7" />
+      <scope id="1841835149314794593" at="134,0,137,0" />
+      <scope id="3913486790550322578" at="156,0,159,0">
         <var name="message" id="3913486790550345920" />
       </scope>
-      <scope id="1841835149314710239" at="123,0,126,0">
+      <scope id="1841835149314710239" at="159,0,162,0">
         <var name="cause" id="1841835149314771714" />
         <var name="message" id="1841835149314710248" />
       </scope>
+      <scope id="4806869284675670" at="95,29,99,18" />
       <scope id="6723782765629113511" at="20,62,25,44">
         <var name="basePath" id="6723782765629118744" />
       </scope>
+      <scope id="4806869284743557" at="107,16,112,5">
+        <var name="in" id="4806869284743560" />
+      </scope>
+      <scope id="4806869284666922" at="94,42,100,11" />
       <scope id="6723782765629113508" at="19,0,27,0">
         <var name="module" id="6723782765629115140" />
       </scope>
-      <scope id="2617896750899006667" at="107,69,115,16" />
-      <scope id="2617896750899006664" at="107,0,117,0">
+      <scope id="4806869284666920" at="93,44,101,9">
+        <var name="j" id="4806869284666921" />
+      </scope>
+      <scope id="4806869284688138" at="93,44,101,9" />
+      <scope id="2617896750899006667" at="143,69,151,16" />
+      <scope id="2617896750899006664" at="143,0,153,0">
         <var name="addSlash" id="2617896750899006711" />
         <var name="path" id="2617896750899006709" />
       </scope>
-      <scope id="6099797596647572299" at="79,69,94,5" />
-      <scope id="6099797596647572297" at="79,0,96,0">
+      <scope id="4806869284626540" at="87,47,102,7" />
+      <scope id="6099797596647572299" at="116,69,131,5" />
+      <scope id="4806869284626538" at="86,0,103,5">
+        <var name="i" id="4806869284626541" />
+      </scope>
+      <scope id="6099797596647572297" at="116,0,133,0">
         <var name="shortPath" id="6099797596647572369" />
       </scope>
       <scope id="1841835149314774677" at="42,9,73,33">
@@ -2183,14 +2224,23 @@
         <var name="relative" id="3913486790551147050" />
         <var name="target" id="3913486790549702755" />
       </scope>
+      <scope id="4806869284588730" at="82,56,113,18">
+        <var name="ignore" id="4806869284611161" />
+        <var name="out" id="4806869284763158" />
+        <var name="remainingCount" id="4806869284691510" />
+        <var name="result" id="4806869284710012" />
+      </scope>
+      <scope id="4806869284588728" at="82,0,115,0">
+        <var name="segments" id="4806869284588734" />
+      </scope>
       <scope id="6099797596647572260" at="32,68,76,5">
         <var name="normalized" id="1841835149314652670" />
       </scope>
       <scope id="6099797596647572258" at="32,0,78,0">
         <var name="fullPath" id="6099797596647572295" />
       </scope>
-      <unit id="1841835149314710237" at="119,0,127,0" name="jetbrains.mps.build.util.RelativePathHelper$PathException" />
-      <unit id="6099797596647572228" at="10,0,128,0" name="jetbrains.mps.build.util.RelativePathHelper" />
+      <unit id="1841835149314710237" at="155,0,163,0" name="jetbrains.mps.build.util.RelativePathHelper$PathException" />
+      <unit id="6099797596647572228" at="10,0,164,0" name="jetbrains.mps.build.util.RelativePathHelper" />
     </file>
   </root>
   <root nodeRef="r:26eadcf0-f275-4e90-be37-e4432772a74d(jetbrains.mps.build.util)/6354776497051832724">

--- a/plugins/mps-build/languages/build/utilModels/jetbrains/mps/buildScript/util.mps
+++ b/plugins/mps-build/languages/build/utilModels/jetbrains/mps/buildScript/util.mps
@@ -27,6 +27,7 @@
     <import index="c17a" ref="8865b7a8-5271-43d3-884c-6fd1d9cfdd34/java:org.jetbrains.mps.openapi.language(MPS.OpenAPI/)" />
     <import index="g3l6" ref="6ed54515-acc8-4d1e-a16c-9fd6cfe951ea/java:jetbrains.mps.extapi.model(MPS.Core/)" />
     <import index="ap4t" ref="215c4c45-ba99-49f5-9ab7-4b6901a63cfd/java:jetbrains.mps.generator(MPS.Generator/)" />
+    <import index="eoo2" ref="6354ebe7-c22a-4a0f-ac54-50b52ab9b065/java:java.nio.file(JDK/)" />
   </imports>
   <registry>
     <language id="a247e09e-2435-45ba-b8d2-07e93feba96a" name="jetbrains.mps.baseLanguage.tuples">
@@ -59,6 +60,7 @@
       </concept>
       <concept id="1153417849900" name="jetbrains.mps.baseLanguage.structure.GreaterThanOrEqualsExpression" flags="nn" index="2d3UOw" />
       <concept id="1215695189714" name="jetbrains.mps.baseLanguage.structure.PlusAssignmentExpression" flags="nn" index="d57v9" />
+      <concept id="1215695201514" name="jetbrains.mps.baseLanguage.structure.MinusAssignmentExpression" flags="nn" index="d5anL" />
       <concept id="4836112446988635817" name="jetbrains.mps.baseLanguage.structure.UndefinedType" flags="in" index="2jxLKc" />
       <concept id="1202948039474" name="jetbrains.mps.baseLanguage.structure.InstanceMethodCallOperation" flags="nn" index="liA8E" />
       <concept id="1179360813171" name="jetbrains.mps.baseLanguage.structure.HexIntegerLiteral" flags="nn" index="2nou5x">
@@ -263,6 +265,13 @@
       </concept>
       <concept id="1073239437375" name="jetbrains.mps.baseLanguage.structure.NotEqualsExpression" flags="nn" index="3y3z36" />
       <concept id="1081855346303" name="jetbrains.mps.baseLanguage.structure.BreakStatement" flags="nn" index="3zACq4" />
+      <concept id="1184950988562" name="jetbrains.mps.baseLanguage.structure.ArrayCreator" flags="nn" index="3$_iS1">
+        <child id="1184951007469" name="componentType" index="3$_nBY" />
+        <child id="1184952969026" name="dimensionExpression" index="3$GQph" />
+      </concept>
+      <concept id="1184952934362" name="jetbrains.mps.baseLanguage.structure.DimensionExpression" flags="nn" index="3$GHV9">
+        <child id="1184953288404" name="expression" index="3$I4v7" />
+      </concept>
       <concept id="1178549954367" name="jetbrains.mps.baseLanguage.structure.IVisible" flags="ng" index="1B3ioH">
         <child id="1178549979242" name="visibility" index="1B3o_S" />
       </concept>
@@ -4049,14 +4058,17 @@
                     <ref role="3uigEE" to="wyt6:~String" resolve="String" />
                   </node>
                 </node>
-                <node concept="2OqwBi" id="3pfvS1vTD$z" role="33vP2m">
-                  <node concept="37vLTw" id="3pfvS1vTFGR" role="2Oq$k0">
-                    <ref role="3cqZAo" node="5iAPpylX$pd" resolve="myBasePath" />
-                  </node>
-                  <node concept="liA8E" id="3pfvS1vTD$$" role="2OqNvi">
-                    <ref role="37wK5l" to="wyt6:~String.split(java.lang.String)" resolve="split" />
-                    <node concept="Xl_RD" id="3pfvS1vTI5k" role="37wK5m">
-                      <property role="Xl_RC" value="/" />
+                <node concept="1rXfSq" id="h4X9ScWRp" role="33vP2m">
+                  <ref role="37wK5l" node="h4X9Sc8MS" resolve="removeDots" />
+                  <node concept="2OqwBi" id="3pfvS1vTD$z" role="37wK5m">
+                    <node concept="37vLTw" id="3pfvS1vTFGR" role="2Oq$k0">
+                      <ref role="3cqZAo" node="5iAPpylX$pd" resolve="myBasePath" />
+                    </node>
+                    <node concept="liA8E" id="3pfvS1vTD$$" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~String.split(java.lang.String)" resolve="split" />
+                      <node concept="Xl_RD" id="3pfvS1vTI5k" role="37wK5m">
+                        <property role="Xl_RC" value="/" />
+                      </node>
                     </node>
                   </node>
                 </node>
@@ -4070,14 +4082,17 @@
                     <ref role="3uigEE" to="wyt6:~String" resolve="String" />
                   </node>
                 </node>
-                <node concept="2OqwBi" id="3pfvS1vTN4G" role="33vP2m">
-                  <node concept="37vLTw" id="3pfvS1vTNLd" role="2Oq$k0">
-                    <ref role="3cqZAo" node="1AfwOXhIBBY" resolve="normalized" />
-                  </node>
-                  <node concept="liA8E" id="3pfvS1vTN4H" role="2OqNvi">
-                    <ref role="37wK5l" to="wyt6:~String.split(java.lang.String)" resolve="split" />
-                    <node concept="Xl_RD" id="3pfvS1vTRcl" role="37wK5m">
-                      <property role="Xl_RC" value="/" />
+                <node concept="1rXfSq" id="h4X9ScZzf" role="33vP2m">
+                  <ref role="37wK5l" node="h4X9Sc8MS" resolve="removeDots" />
+                  <node concept="2OqwBi" id="3pfvS1vTN4G" role="37wK5m">
+                    <node concept="37vLTw" id="3pfvS1vTNLd" role="2Oq$k0">
+                      <ref role="3cqZAo" node="1AfwOXhIBBY" resolve="normalized" />
+                    </node>
+                    <node concept="liA8E" id="3pfvS1vTN4H" role="2OqNvi">
+                      <ref role="37wK5l" to="wyt6:~String.split(java.lang.String)" resolve="split" />
+                      <node concept="Xl_RD" id="3pfvS1vTRcl" role="37wK5m">
+                        <property role="Xl_RC" value="/" />
+                      </node>
                     </node>
                   </node>
                 </node>
@@ -4176,14 +4191,6 @@
               </node>
             </node>
             <node concept="3clFbJ" id="3pfvS1vTSXE" role="3cqZAp">
-              <node concept="3clFbC" id="3pfvS1vTSXF" role="3clFbw">
-                <node concept="37vLTw" id="3pfvS1vTSXG" role="3uHU7B">
-                  <ref role="3cqZAo" node="3pfvS1vTSX8" resolve="commonLength" />
-                </node>
-                <node concept="3cmrfG" id="3pfvS1vTSXH" role="3uHU7w">
-                  <property role="3cmrfH" value="0" />
-                </node>
-              </node>
               <node concept="3clFbS" id="3pfvS1vTSXJ" role="3clFbx">
                 <node concept="YS8fn" id="3pfvS1vTSXU" role="3cqZAp">
                   <node concept="2ShNRf" id="3pfvS1vUzwE" role="YScLw">
@@ -4204,6 +4211,14 @@
                       </node>
                     </node>
                   </node>
+                </node>
+              </node>
+              <node concept="3clFbC" id="3pfvS1vTSXF" role="3clFbw">
+                <node concept="37vLTw" id="3pfvS1vTSXG" role="3uHU7B">
+                  <ref role="3cqZAo" node="3pfvS1vTSX8" resolve="commonLength" />
+                </node>
+                <node concept="3cmrfG" id="3pfvS1vTSXH" role="3uHU7w">
+                  <property role="3cmrfH" value="0" />
                 </node>
               </node>
             </node>
@@ -4661,6 +4676,480 @@
       </node>
       <node concept="17QB3L" id="5iAPpylXsd4" role="3clF45" />
     </node>
+    <node concept="2tJIrI" id="h4X9Sc38y" role="jymVt" />
+    <node concept="2YIFZL" id="h4X9Sc8MS" role="jymVt">
+      <property role="TrG5h" value="removeDots" />
+      <node concept="3clFbS" id="h4X9Sc8MU" role="3clF47">
+        <node concept="3SKdUt" id="h4X9ScRuA" role="3cqZAp">
+          <node concept="1PaTwC" id="h4X9ScRuB" role="1aUNEU">
+            <node concept="3oM_SD" id="h4X9ScRxR" role="1PaTwD">
+              <property role="3oM_SC" value="An" />
+            </node>
+            <node concept="3oM_SD" id="h4X9ScRxS" role="1PaTwD">
+              <property role="3oM_SC" value="array" />
+            </node>
+            <node concept="3oM_SD" id="h4X9ScRxT" role="1PaTwD">
+              <property role="3oM_SC" value="of" />
+            </node>
+            <node concept="3oM_SD" id="h4X9ScRxU" role="1PaTwD">
+              <property role="3oM_SC" value="boolean" />
+            </node>
+            <node concept="3oM_SD" id="h4X9ScRxV" role="1PaTwD">
+              <property role="3oM_SC" value="indicating" />
+            </node>
+            <node concept="3oM_SD" id="h4X9ScRxW" role="1PaTwD">
+              <property role="3oM_SC" value="whether" />
+            </node>
+            <node concept="3oM_SD" id="h4X9ScRxX" role="1PaTwD">
+              <property role="3oM_SC" value="a" />
+            </node>
+            <node concept="3oM_SD" id="h4X9ScRxY" role="1PaTwD">
+              <property role="3oM_SC" value="segment" />
+            </node>
+            <node concept="3oM_SD" id="h4X9ScRxZ" role="1PaTwD">
+              <property role="3oM_SC" value="is" />
+            </node>
+            <node concept="3oM_SD" id="h4X9ScRy6" role="1PaTwD">
+              <property role="3oM_SC" value="excluded" />
+            </node>
+            <node concept="3oM_SD" id="h4X9ScRy7" role="1PaTwD">
+              <property role="3oM_SC" value="from" />
+            </node>
+            <node concept="3oM_SD" id="h4X9ScRy8" role="1PaTwD">
+              <property role="3oM_SC" value="the" />
+            </node>
+            <node concept="3oM_SD" id="h4X9ScRya" role="1PaTwD">
+              <property role="3oM_SC" value="final" />
+            </node>
+            <node concept="3oM_SD" id="h4X9ScRy9" role="1PaTwD">
+              <property role="3oM_SC" value="result" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="h4X9Scehm" role="3cqZAp">
+          <node concept="3cpWsn" id="h4X9Scehp" role="3cpWs9">
+            <property role="TrG5h" value="ignore" />
+            <node concept="10Q1$e" id="h4X9Scehr" role="1tU5fm">
+              <node concept="10P_77" id="h4X9Sceht" role="10Q1$1" />
+            </node>
+            <node concept="2ShNRf" id="h4X9Sce$A" role="33vP2m">
+              <node concept="3$_iS1" id="h4X9ScgPW" role="2ShVmc">
+                <node concept="3$GHV9" id="h4X9ScgPY" role="3$GQph">
+                  <node concept="2OqwBi" id="h4X9Sch2G" role="3$I4v7">
+                    <node concept="37vLTw" id="h4X9ScgVX" role="2Oq$k0">
+                      <ref role="3cqZAo" node="h4X9Sc8MY" resolve="segments" />
+                    </node>
+                    <node concept="1Rwk04" id="h4X9SchUh" role="2OqNvi" />
+                  </node>
+                </node>
+                <node concept="10P_77" id="h4X9ScgNm" role="3$_nBY" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="h4X9ScxSN" role="3cqZAp">
+          <node concept="3cpWsn" id="h4X9ScxSQ" role="3cpWs9">
+            <property role="TrG5h" value="remainingCount" />
+            <node concept="10Oyi0" id="h4X9ScxSL" role="1tU5fm" />
+            <node concept="2OqwBi" id="h4X9ScGrf" role="33vP2m">
+              <node concept="37vLTw" id="h4X9ScFQd" role="2Oq$k0">
+                <ref role="3cqZAo" node="h4X9Sc8MY" resolve="segments" />
+              </node>
+              <node concept="1Rwk04" id="h4X9ScH6V" role="2OqNvi" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="h4X9SchXD" role="3cqZAp" />
+        <node concept="1Dw8fO" id="h4X9Sci1E" role="3cqZAp">
+          <node concept="3clFbS" id="h4X9Sci1G" role="2LFqv$">
+            <node concept="3SKdUt" id="h4X9ScRA7" role="3cqZAp">
+              <node concept="1PaTwC" id="h4X9ScRA8" role="1aUNEU">
+                <node concept="3oM_SD" id="h4X9ScRDo" role="1PaTwD">
+                  <property role="3oM_SC" value="Ignore" />
+                </node>
+                <node concept="3oM_SD" id="h4X9ScRDp" role="1PaTwD">
+                  <property role="3oM_SC" value="each" />
+                </node>
+                <node concept="3oM_SD" id="h4X9ScRDq" role="1PaTwD">
+                  <property role="3oM_SC" value="'.'." />
+                </node>
+              </node>
+            </node>
+            <node concept="3SKdUt" id="h4X9ScRHo" role="3cqZAp">
+              <node concept="1PaTwC" id="h4X9ScRHp" role="1aUNEU">
+                <node concept="3oM_SD" id="h4X9ScRHs" role="1PaTwD">
+                  <property role="3oM_SC" value="In" />
+                </node>
+                <node concept="3oM_SD" id="h4X9ScRHt" role="1PaTwD">
+                  <property role="3oM_SC" value="case" />
+                </node>
+                <node concept="3oM_SD" id="h4X9ScRHu" role="1PaTwD">
+                  <property role="3oM_SC" value="of" />
+                </node>
+                <node concept="3oM_SD" id="h4X9ScRHv" role="1PaTwD">
+                  <property role="3oM_SC" value="'..'," />
+                </node>
+                <node concept="3oM_SD" id="h4X9ScRLf" role="1PaTwD">
+                  <property role="3oM_SC" value="ignore" />
+                </node>
+                <node concept="3oM_SD" id="h4X9ScRQG" role="1PaTwD">
+                  <property role="3oM_SC" value="it" />
+                </node>
+                <node concept="3oM_SD" id="h4X9ScRQH" role="1PaTwD">
+                  <property role="3oM_SC" value="only" />
+                </node>
+                <node concept="3oM_SD" id="h4X9ScRQI" role="1PaTwD">
+                  <property role="3oM_SC" value="if" />
+                </node>
+                <node concept="3oM_SD" id="h4X9ScRME" role="1PaTwD">
+                  <property role="3oM_SC" value="it" />
+                </node>
+                <node concept="3oM_SD" id="h4X9ScRMV" role="1PaTwD">
+                  <property role="3oM_SC" value="is" />
+                </node>
+                <node concept="3oM_SD" id="h4X9ScRMW" role="1PaTwD">
+                  <property role="3oM_SC" value="preceded" />
+                </node>
+                <node concept="3oM_SD" id="h4X9ScRNd" role="1PaTwD">
+                  <property role="3oM_SC" value="by" />
+                </node>
+                <node concept="3oM_SD" id="h4X9ScRNe" role="1PaTwD">
+                  <property role="3oM_SC" value="a" />
+                </node>
+                <node concept="3oM_SD" id="h4X9ScRNf" role="1PaTwD">
+                  <property role="3oM_SC" value="non-ignored" />
+                </node>
+                <node concept="3oM_SD" id="h4X9ScRNw" role="1PaTwD">
+                  <property role="3oM_SC" value="segment," />
+                </node>
+                <node concept="3oM_SD" id="h4X9ScRNL" role="1PaTwD">
+                  <property role="3oM_SC" value="ignore" />
+                </node>
+                <node concept="3oM_SD" id="h4X9ScROi" role="1PaTwD">
+                  <property role="3oM_SC" value="that" />
+                </node>
+                <node concept="3oM_SD" id="h4X9ScROj" role="1PaTwD">
+                  <property role="3oM_SC" value="segment" />
+                </node>
+                <node concept="3oM_SD" id="h4X9ScRRf" role="1PaTwD">
+                  <property role="3oM_SC" value="as" />
+                </node>
+                <node concept="3oM_SD" id="h4X9ScRRK" role="1PaTwD">
+                  <property role="3oM_SC" value="well." />
+                </node>
+              </node>
+            </node>
+            <node concept="3clFbJ" id="h4X9ScljI" role="3cqZAp">
+              <node concept="3clFbS" id="h4X9ScljK" role="3clFbx">
+                <node concept="3clFbF" id="h4X9Scmv7" role="3cqZAp">
+                  <node concept="37vLTI" id="h4X9ScoB1" role="3clFbG">
+                    <node concept="3clFbT" id="h4X9ScoCB" role="37vLTx">
+                      <property role="3clFbU" value="true" />
+                    </node>
+                    <node concept="AH0OO" id="h4X9ScovV" role="37vLTJ">
+                      <node concept="37vLTw" id="h4X9ScozH" role="AHEQo">
+                        <ref role="3cqZAo" node="h4X9Sci1H" resolve="i" />
+                      </node>
+                      <node concept="37vLTw" id="h4X9ScogG" role="AHHXb">
+                        <ref role="3cqZAo" node="h4X9Scehp" resolve="ignore" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="3clFbF" id="h4X9Scya8" role="3cqZAp">
+                  <node concept="3uO5VW" id="h4X9ScHHw" role="3clFbG">
+                    <node concept="37vLTw" id="h4X9ScHHy" role="2$L3a6">
+                      <ref role="3cqZAo" node="h4X9ScxSQ" resolve="remainingCount" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="2OqwBi" id="h4X9SflDQ" role="3clFbw">
+                <node concept="liA8E" id="h4X9SflDT" role="2OqNvi">
+                  <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
+                  <node concept="AH0OO" id="h4X9SclvE" role="37wK5m">
+                    <node concept="37vLTw" id="h4X9SclDl" role="AHEQo">
+                      <ref role="3cqZAo" node="h4X9Sci1H" resolve="i" />
+                    </node>
+                    <node concept="37vLTw" id="h4X9Sclpr" role="AHHXb">
+                      <ref role="3cqZAo" node="h4X9Sc8MY" resolve="segments" />
+                    </node>
+                  </node>
+                </node>
+                <node concept="Xl_RD" id="h4X9ScmpA" role="2Oq$k0">
+                  <property role="Xl_RC" value="." />
+                </node>
+              </node>
+              <node concept="3eNFk2" id="h4X9Scx48" role="3eNLev">
+                <node concept="3clFbS" id="h4X9Scx4a" role="3eOfB_">
+                  <node concept="1Dw8fO" id="h4X9ScrSC" role="3cqZAp">
+                    <node concept="3cpWsn" id="h4X9ScrSD" role="1Duv9x">
+                      <property role="TrG5h" value="j" />
+                      <node concept="10Oyi0" id="h4X9ScrVv" role="1tU5fm" />
+                      <node concept="3cpWsd" id="h4X9Scs1O" role="33vP2m">
+                        <node concept="3cmrfG" id="h4X9Scs2e" role="3uHU7w">
+                          <property role="3cmrfH" value="1" />
+                        </node>
+                        <node concept="37vLTw" id="h4X9Scs1z" role="3uHU7B">
+                          <ref role="3cqZAo" node="h4X9Sci1H" resolve="i" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="3clFbS" id="h4X9ScrSE" role="2LFqv$">
+                      <node concept="3clFbJ" id="h4X9Scu1k" role="3cqZAp">
+                        <node concept="3fqX7Q" id="h4X9Scu6J" role="3clFbw">
+                          <node concept="AH0OO" id="h4X9ScugO" role="3fr31v">
+                            <node concept="37vLTw" id="h4X9Sculd" role="AHEQo">
+                              <ref role="3cqZAo" node="h4X9ScrSD" resolve="j" />
+                            </node>
+                            <node concept="37vLTw" id="h4X9Scu8$" role="AHHXb">
+                              <ref role="3cqZAo" node="h4X9Scehp" resolve="ignore" />
+                            </node>
+                          </node>
+                        </node>
+                        <node concept="3clFbS" id="h4X9Scu1m" role="3clFbx">
+                          <node concept="3clFbF" id="h4X9ScuqE" role="3cqZAp">
+                            <node concept="37vLTI" id="h4X9Scwah" role="3clFbG">
+                              <node concept="3clFbT" id="h4X9ScwbR" role="37vLTx">
+                                <property role="3clFbU" value="true" />
+                              </node>
+                              <node concept="AH0OO" id="h4X9Scutt" role="37vLTJ">
+                                <node concept="37vLTw" id="h4X9ScuwZ" role="AHEQo">
+                                  <ref role="3cqZAo" node="h4X9ScrSD" resolve="j" />
+                                </node>
+                                <node concept="37vLTw" id="h4X9ScuqD" role="AHHXb">
+                                  <ref role="3cqZAo" node="h4X9Scehp" resolve="ignore" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3clFbF" id="h4X9Scwk8" role="3cqZAp">
+                            <node concept="37vLTI" id="h4X9ScwUA" role="3clFbG">
+                              <node concept="3clFbT" id="h4X9ScwWc" role="37vLTx">
+                                <property role="3clFbU" value="true" />
+                              </node>
+                              <node concept="AH0OO" id="h4X9Scwp3" role="37vLTJ">
+                                <node concept="37vLTw" id="h4X9ScwsW" role="AHEQo">
+                                  <ref role="3cqZAo" node="h4X9Sci1H" resolve="i" />
+                                </node>
+                                <node concept="37vLTw" id="h4X9Scwk6" role="AHHXb">
+                                  <ref role="3cqZAo" node="h4X9Scehp" resolve="ignore" />
+                                </node>
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3clFbF" id="h4X9SczZF" role="3cqZAp">
+                            <node concept="d5anL" id="h4X9ScHZJ" role="3clFbG">
+                              <node concept="37vLTw" id="h4X9ScHZM" role="37vLTJ">
+                                <ref role="3cqZAo" node="h4X9ScxSQ" resolve="remainingCount" />
+                              </node>
+                              <node concept="3cmrfG" id="h4X9ScHZL" role="37vLTx">
+                                <property role="3cmrfH" value="2" />
+                              </node>
+                            </node>
+                          </node>
+                          <node concept="3zACq4" id="h4X9Scx1j" role="3cqZAp" />
+                        </node>
+                      </node>
+                    </node>
+                    <node concept="2d3UOw" id="h4X9Scsrq" role="1Dwp0S">
+                      <node concept="37vLTw" id="h4X9Scs5C" role="3uHU7B">
+                        <ref role="3cqZAo" node="h4X9ScrSD" resolve="j" />
+                      </node>
+                      <node concept="3cmrfG" id="h4X9Scson" role="3uHU7w">
+                        <property role="3cmrfH" value="0" />
+                      </node>
+                    </node>
+                    <node concept="3uO5VW" id="h4X9SctNV" role="1Dwrff">
+                      <node concept="37vLTw" id="h4X9SctNX" role="2$L3a6">
+                        <ref role="3cqZAo" node="h4X9ScrSD" resolve="j" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+                <node concept="2OqwBi" id="h4X9Sfr2_" role="3eO9$A">
+                  <node concept="liA8E" id="h4X9Sfr2C" role="2OqNvi">
+                    <ref role="37wK5l" to="wyt6:~String.equals(java.lang.Object)" resolve="equals" />
+                    <node concept="AH0OO" id="h4X9Scxp4" role="37wK5m">
+                      <node concept="37vLTw" id="h4X9Scxp5" role="AHEQo">
+                        <ref role="3cqZAo" node="h4X9Sci1H" resolve="i" />
+                      </node>
+                      <node concept="37vLTw" id="h4X9Scxp6" role="AHHXb">
+                        <ref role="3cqZAo" node="h4X9Sc8MY" resolve="segments" />
+                      </node>
+                    </node>
+                  </node>
+                  <node concept="Xl_RD" id="h4X9Scxp3" role="2Oq$k0">
+                    <property role="Xl_RC" value=".." />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWsn" id="h4X9Sci1H" role="1Duv9x">
+            <property role="TrG5h" value="i" />
+            <node concept="10Oyi0" id="h4X9Sci4r" role="1tU5fm" />
+            <node concept="3cmrfG" id="h4X9Scido" role="33vP2m">
+              <property role="3cmrfH" value="0" />
+            </node>
+          </node>
+          <node concept="3eOVzh" id="h4X9ScjIm" role="1Dwp0S">
+            <node concept="2OqwBi" id="h4X9ScklR" role="3uHU7w">
+              <node concept="37vLTw" id="h4X9ScjOs" role="2Oq$k0">
+                <ref role="3cqZAo" node="h4X9Sc8MY" resolve="segments" />
+              </node>
+              <node concept="1Rwk04" id="h4X9Scl1U" role="2OqNvi" />
+            </node>
+            <node concept="37vLTw" id="h4X9ScigU" role="3uHU7B">
+              <ref role="3cqZAo" node="h4X9Sci1H" resolve="i" />
+            </node>
+          </node>
+          <node concept="3uNrnE" id="h4X9Sclfn" role="1Dwrff">
+            <node concept="37vLTw" id="h4X9Sclfp" role="2$L3a6">
+              <ref role="3cqZAo" node="h4X9Sci1H" resolve="i" />
+            </node>
+          </node>
+        </node>
+        <node concept="3clFbH" id="h4X9ScxLL" role="3cqZAp" />
+        <node concept="3SKdUt" id="h4X9ScRWd" role="3cqZAp">
+          <node concept="1PaTwC" id="h4X9ScRWe" role="1aUNEU">
+            <node concept="3oM_SD" id="h4X9ScRWh" role="1PaTwD">
+              <property role="3oM_SC" value="Return" />
+            </node>
+            <node concept="3oM_SD" id="h4X9ScRWi" role="1PaTwD">
+              <property role="3oM_SC" value="an" />
+            </node>
+            <node concept="3oM_SD" id="h4X9ScRWj" role="1PaTwD">
+              <property role="3oM_SC" value="array" />
+            </node>
+            <node concept="3oM_SD" id="h4X9ScRWk" role="1PaTwD">
+              <property role="3oM_SC" value="of" />
+            </node>
+            <node concept="3oM_SD" id="h4X9ScRWl" role="1PaTwD">
+              <property role="3oM_SC" value="all" />
+            </node>
+            <node concept="3oM_SD" id="h4X9ScRWm" role="1PaTwD">
+              <property role="3oM_SC" value="non-ignored" />
+            </node>
+            <node concept="3oM_SD" id="h4X9ScRZ$" role="1PaTwD">
+              <property role="3oM_SC" value="segments." />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="h4X9ScApT" role="3cqZAp">
+          <node concept="3cpWsn" id="h4X9ScApW" role="3cpWs9">
+            <property role="TrG5h" value="result" />
+            <node concept="10Q1$e" id="h4X9ScAw0" role="1tU5fm">
+              <node concept="17QB3L" id="h4X9ScApR" role="10Q1$1" />
+            </node>
+            <node concept="2ShNRf" id="h4X9ScABW" role="33vP2m">
+              <node concept="3$_iS1" id="h4X9ScCD6" role="2ShVmc">
+                <node concept="3$GHV9" id="h4X9ScCD8" role="3$GQph">
+                  <node concept="37vLTw" id="h4X9ScItB" role="3$I4v7">
+                    <ref role="3cqZAo" node="h4X9ScxSQ" resolve="remainingCount" />
+                  </node>
+                </node>
+                <node concept="17QB3L" id="h4X9ScCAE" role="3$_nBY" />
+              </node>
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs8" id="h4X9ScNoj" role="3cqZAp">
+          <node concept="3cpWsn" id="h4X9ScNom" role="3cpWs9">
+            <property role="TrG5h" value="out" />
+            <node concept="10Oyi0" id="h4X9ScNoh" role="1tU5fm" />
+            <node concept="3cmrfG" id="h4X9ScNw2" role="33vP2m">
+              <property role="3cmrfH" value="0" />
+            </node>
+          </node>
+        </node>
+        <node concept="1Dw8fO" id="h4X9ScIA5" role="3cqZAp">
+          <node concept="3clFbS" id="h4X9ScIA7" role="2LFqv$">
+            <node concept="3clFbJ" id="h4X9ScPAG" role="3cqZAp">
+              <node concept="3clFbS" id="h4X9ScPAI" role="3clFbx">
+                <node concept="3clFbF" id="h4X9ScMZQ" role="3cqZAp">
+                  <node concept="37vLTI" id="h4X9ScQ$W" role="3clFbG">
+                    <node concept="AH0OO" id="h4X9ScRb8" role="37vLTx">
+                      <node concept="37vLTw" id="h4X9ScRp_" role="AHEQo">
+                        <ref role="3cqZAo" node="h4X9ScIA8" resolve="in" />
+                      </node>
+                      <node concept="37vLTw" id="h4X9ScQPf" role="AHHXb">
+                        <ref role="3cqZAo" node="h4X9Sc8MY" resolve="segments" />
+                      </node>
+                    </node>
+                    <node concept="AH0OO" id="h4X9ScO1v" role="37vLTJ">
+                      <node concept="3uNrnE" id="h4X9ScPly" role="AHEQo">
+                        <node concept="37vLTw" id="h4X9ScPl$" role="2$L3a6">
+                          <ref role="3cqZAo" node="h4X9ScNom" resolve="out" />
+                        </node>
+                      </node>
+                      <node concept="37vLTw" id="h4X9ScMZO" role="AHHXb">
+                        <ref role="3cqZAo" node="h4X9ScApW" resolve="result" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3fqX7Q" id="h4X9ScPEM" role="3clFbw">
+                <node concept="AH0OO" id="h4X9ScPLC" role="3fr31v">
+                  <node concept="37vLTw" id="h4X9ScPQt" role="AHEQo">
+                    <ref role="3cqZAo" node="h4X9ScIA8" resolve="in" />
+                  </node>
+                  <node concept="37vLTw" id="h4X9ScPGB" role="AHHXb">
+                    <ref role="3cqZAo" node="h4X9Scehp" resolve="ignore" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3cpWsn" id="h4X9ScIA8" role="1Duv9x">
+            <property role="TrG5h" value="in" />
+            <node concept="10Oyi0" id="h4X9ScIDi" role="1tU5fm" />
+            <node concept="3cmrfG" id="h4X9ScIHO" role="33vP2m">
+              <property role="3cmrfH" value="0" />
+            </node>
+          </node>
+          <node concept="3eOVzh" id="h4X9ScKfj" role="1Dwp0S">
+            <node concept="2OqwBi" id="h4X9ScKNi" role="3uHU7w">
+              <node concept="37vLTw" id="h4X9ScKhR" role="2Oq$k0">
+                <ref role="3cqZAo" node="h4X9Sc8MY" resolve="segments" />
+              </node>
+              <node concept="1Rwk04" id="h4X9ScLwQ" role="2OqNvi" />
+            </node>
+            <node concept="37vLTw" id="h4X9ScILM" role="3uHU7B">
+              <ref role="3cqZAo" node="h4X9ScIA8" resolve="i" />
+            </node>
+          </node>
+          <node concept="3uNrnE" id="h4X9ScMTX" role="1Dwrff">
+            <node concept="37vLTw" id="h4X9ScMTZ" role="2$L3a6">
+              <ref role="3cqZAo" node="h4X9ScIA8" resolve="i" />
+            </node>
+          </node>
+        </node>
+        <node concept="3cpWs6" id="h4X9ScS5t" role="3cqZAp">
+          <node concept="37vLTw" id="h4X9ScS82" role="3cqZAk">
+            <ref role="3cqZAo" node="h4X9ScApW" resolve="result" />
+          </node>
+        </node>
+      </node>
+      <node concept="10Q1$e" id="h4X9Sc8MW" role="3clF45">
+        <node concept="17QB3L" id="h4X9Sc8MX" role="10Q1$1" />
+      </node>
+      <node concept="37vLTG" id="h4X9Sc8MY" role="3clF46">
+        <property role="TrG5h" value="segments" />
+        <node concept="10Q1$e" id="h4X9Sc8MZ" role="1tU5fm">
+          <node concept="17QB3L" id="h4X9Sc8N0" role="10Q1$1" />
+        </node>
+      </node>
+      <node concept="3Tm1VV" id="h4X9SdEoH" role="1B3o_S" />
+      <node concept="P$JXv" id="h4X9SccMx" role="lGtFl">
+        <node concept="TZ5HA" id="h4X9SccMy" role="TZ5H$">
+          <node concept="1dT_AC" id="h4X9SccP5" role="1dT_Ay">
+            <property role="1dT_AB" value="Normalize segments to resolve '.' and '..' according to standard rules." />
+          </node>
+        </node>
+      </node>
+    </node>
     <node concept="2tJIrI" id="4WwUR8htLIs" role="jymVt" />
     <node concept="3clFb_" id="5iAPpylXsd9" role="jymVt">
       <property role="TrG5h" value="makeAbsolute" />
@@ -4862,7 +5351,6 @@
       </node>
     </node>
     <node concept="2tJIrI" id="4WwUR8ht$v7" role="jymVt" />
-    <node concept="2tJIrI" id="4WwUR8ht_W5" role="jymVt" />
     <node concept="2YIFZL" id="2hkCNA7Z0N8" role="jymVt">
       <property role="TrG5h" value="normalizePath" />
       <node concept="37vLTG" id="2hkCNA7Z0NP" role="3clF46">

--- a/plugins/mps-build/test/jetbrains.mps.build.tests/models/jetbrains/mps/build/tests@tests.mps
+++ b/plugins/mps-build/test/jetbrains.mps.build.tests/models/jetbrains/mps/build/tests@tests.mps
@@ -46,6 +46,9 @@
       <concept id="1225978065297" name="jetbrains.mps.lang.test.structure.SimpleNodeTest" flags="ng" index="1LZb2c" />
     </language>
     <language id="f3061a53-9226-4cc5-a443-f952ceaf5816" name="jetbrains.mps.baseLanguage">
+      <concept id="1082485599095" name="jetbrains.mps.baseLanguage.structure.BlockStatement" flags="nn" index="9aQIb">
+        <child id="1082485599096" name="statements" index="9aQI4" />
+      </concept>
       <concept id="1215693861676" name="jetbrains.mps.baseLanguage.structure.BaseAssignmentExpression" flags="nn" index="d038R">
         <child id="1068498886297" name="rValue" index="37vLTx" />
         <child id="1068498886295" name="lValue" index="37vLTJ" />
@@ -90,6 +93,9 @@
       <concept id="1068431474542" name="jetbrains.mps.baseLanguage.structure.VariableDeclaration" flags="ng" index="33uBYm">
         <property id="1176718929932" name="isFinal" index="3TUv4t" />
         <child id="1068431790190" name="initializer" index="33vP2m" />
+      </concept>
+      <concept id="1513279640923991009" name="jetbrains.mps.baseLanguage.structure.IGenericClassCreator" flags="ng" index="366HgL">
+        <property id="1513279640906337053" name="inferTypeParams" index="373rjd" />
       </concept>
       <concept id="1068498886296" name="jetbrains.mps.baseLanguage.structure.VariableReference" flags="nn" index="37vLTw">
         <reference id="1068581517664" name="variableDeclaration" index="3cqZAo" />
@@ -157,6 +163,14 @@
       <concept id="1146644602865" name="jetbrains.mps.baseLanguage.structure.PublicVisibility" flags="nn" index="3Tm1VV" />
       <concept id="1146644623116" name="jetbrains.mps.baseLanguage.structure.PrivateVisibility" flags="nn" index="3Tm6S6" />
       <concept id="1146644641414" name="jetbrains.mps.baseLanguage.structure.ProtectedVisibility" flags="nn" index="3Tmbuc" />
+      <concept id="1116615150612" name="jetbrains.mps.baseLanguage.structure.ClassifierClassExpression" flags="nn" index="3VsKOn">
+        <reference id="1116615189566" name="classifier" index="3VsUkX" />
+      </concept>
+    </language>
+    <language id="fd392034-7849-419d-9071-12563d152375" name="jetbrains.mps.baseLanguage.closures">
+      <concept id="1199569711397" name="jetbrains.mps.baseLanguage.closures.structure.ClosureLiteral" flags="nn" index="1bVj0M">
+        <child id="1199569916463" name="body" index="1bW5cS" />
+      </concept>
     </language>
     <language id="443f4c36-fcf5-4eb6-9500-8d06ed259e3e" name="jetbrains.mps.baseLanguage.classifiers">
       <concept id="1205752633985" name="jetbrains.mps.baseLanguage.classifiers.structure.ThisClassifierExpression" flags="nn" index="2WthIp" />
@@ -2508,6 +2522,266 @@
                   <ref role="37wK5l" to="o3n2:5iAPpylXsd9" resolve="makeAbsolute" />
                   <node concept="Xl_RD" id="1AfwOXhJ77M" role="37wK5m">
                     <property role="Xl_RC" value="../" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3s$Bmu" id="h4X9S5vWM" role="3s_gse">
+        <property role="3s$Bm0" value="dots" />
+        <node concept="3cqZAl" id="h4X9S5vWN" role="3clF45" />
+        <node concept="3Tm1VV" id="h4X9S5vWO" role="1B3o_S" />
+        <node concept="3clFbS" id="h4X9S5vWP" role="3clF47">
+          <node concept="9aQIb" id="h4X9SaKm$" role="3cqZAp">
+            <node concept="3clFbS" id="h4X9SaKmA" role="9aQI4">
+              <node concept="3cpWs8" id="h4X9S5wSd" role="3cqZAp">
+                <node concept="3cpWsn" id="h4X9S5wSe" role="3cpWs9">
+                  <property role="TrG5h" value="rph" />
+                  <node concept="3uibUv" id="h4X9S5wSf" role="1tU5fm">
+                    <ref role="3uigEE" to="o3n2:5iAPpylXsc4" resolve="RelativePathHelper" />
+                  </node>
+                  <node concept="2ShNRf" id="h4X9S5wW_" role="33vP2m">
+                    <node concept="1pGfFk" id="h4X9S5yYO" role="2ShVmc">
+                      <property role="373rjd" value="true" />
+                      <ref role="37wK5l" to="o3n2:1AfwOXhIBBI" resolve="RelativePathHelper" />
+                      <node concept="Xl_RD" id="h4X9S5z2t" role="37wK5m">
+                        <property role="Xl_RC" value="/root/./a/./b/../.." />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="h4X9S5zka" role="3cqZAp">
+                <node concept="2YIFZM" id="h4X9S5zvy" role="3clFbG">
+                  <ref role="37wK5l" to="rjhg:~Assert.assertEquals(java.lang.Object,java.lang.Object)" resolve="assertEquals" />
+                  <ref role="1Pybhc" to="rjhg:~Assert" resolve="Assert" />
+                  <node concept="Xl_RD" id="h4X9S5zDS" role="37wK5m">
+                    <property role="Xl_RC" value="a/b" />
+                  </node>
+                  <node concept="2OqwBi" id="h4X9S5$fk" role="37wK5m">
+                    <node concept="37vLTw" id="h4X9S5$93" role="2Oq$k0">
+                      <ref role="3cqZAo" node="h4X9S5wSe" resolve="rph" />
+                    </node>
+                    <node concept="liA8E" id="h4X9S5_ee" role="2OqNvi">
+                      <ref role="37wK5l" to="o3n2:5iAPpylXscy" resolve="makeRelative" />
+                      <node concept="Xl_RD" id="h4X9S5_pw" role="37wK5m">
+                        <property role="Xl_RC" value="/root/a/b" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="h4X9S8EJ3" role="3cqZAp">
+                <node concept="2YIFZM" id="h4X9S8EJ4" role="3clFbG">
+                  <ref role="37wK5l" to="rjhg:~Assert.assertEquals(java.lang.Object,java.lang.Object)" resolve="assertEquals" />
+                  <ref role="1Pybhc" to="rjhg:~Assert" resolve="Assert" />
+                  <node concept="Xl_RD" id="h4X9S8EJ5" role="37wK5m">
+                    <property role="Xl_RC" value="c/d/" />
+                  </node>
+                  <node concept="2OqwBi" id="h4X9S8EJ6" role="37wK5m">
+                    <node concept="37vLTw" id="h4X9S8EJ7" role="2Oq$k0">
+                      <ref role="3cqZAo" node="h4X9S5wSe" resolve="rph" />
+                    </node>
+                    <node concept="liA8E" id="h4X9S8EJ8" role="2OqNvi">
+                      <ref role="37wK5l" to="o3n2:5iAPpylXscy" resolve="makeRelative" />
+                      <node concept="Xl_RD" id="h4X9S8EJ9" role="37wK5m">
+                        <property role="Xl_RC" value="/root/c/d/" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="h4X9Sh$3U" role="3cqZAp">
+                <node concept="2YIFZM" id="h4X9Sh$3V" role="3clFbG">
+                  <ref role="37wK5l" to="rjhg:~Assert.assertEquals(java.lang.Object,java.lang.Object)" resolve="assertEquals" />
+                  <ref role="1Pybhc" to="rjhg:~Assert" resolve="Assert" />
+                  <node concept="Xl_RD" id="h4X9Sh$3W" role="37wK5m">
+                    <property role="Xl_RC" value="c/d/" />
+                  </node>
+                  <node concept="2OqwBi" id="h4X9Sh$3X" role="37wK5m">
+                    <node concept="37vLTw" id="h4X9Sh$3Y" role="2Oq$k0">
+                      <ref role="3cqZAo" node="h4X9S5wSe" resolve="rph" />
+                    </node>
+                    <node concept="liA8E" id="h4X9Sh$3Z" role="2OqNvi">
+                      <ref role="37wK5l" to="o3n2:5iAPpylXscy" resolve="makeRelative" />
+                      <node concept="Xl_RD" id="h4X9Sh$40" role="37wK5m">
+                        <property role="Xl_RC" value="/root/c/./e/../d/./" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="h4X9S9j9O" role="3cqZAp" />
+          <node concept="9aQIb" id="h4X9SaL1i" role="3cqZAp">
+            <node concept="3clFbS" id="h4X9SaL1k" role="9aQI4">
+              <node concept="3cpWs8" id="h4X9S9jzn" role="3cqZAp">
+                <node concept="3cpWsn" id="h4X9S9jzo" role="3cpWs9">
+                  <property role="TrG5h" value="rph" />
+                  <node concept="3uibUv" id="h4X9S9jzp" role="1tU5fm">
+                    <ref role="3uigEE" to="o3n2:5iAPpylXsc4" resolve="RelativePathHelper" />
+                  </node>
+                  <node concept="2ShNRf" id="h4X9S9jHE" role="33vP2m">
+                    <node concept="1pGfFk" id="h4X9S9kzj" role="2ShVmc">
+                      <property role="373rjd" value="true" />
+                      <ref role="37wK5l" to="o3n2:1AfwOXhIBBI" resolve="RelativePathHelper" />
+                      <node concept="Xl_RD" id="h4X9S9kHI" role="37wK5m">
+                        <property role="Xl_RC" value="/a/b/c/d/../.." />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="h4X9S9l9L" role="3cqZAp">
+                <node concept="2YIFZM" id="h4X9S9l9M" role="3clFbG">
+                  <ref role="37wK5l" to="rjhg:~Assert.assertEquals(java.lang.Object,java.lang.Object)" resolve="assertEquals" />
+                  <ref role="1Pybhc" to="rjhg:~Assert" resolve="Assert" />
+                  <node concept="Xl_RD" id="h4X9S9l9N" role="37wK5m">
+                    <property role="Xl_RC" value="c/d" />
+                  </node>
+                  <node concept="2OqwBi" id="h4X9S9l9O" role="37wK5m">
+                    <node concept="37vLTw" id="h4X9S9l9P" role="2Oq$k0">
+                      <ref role="3cqZAo" node="h4X9S9jzo" resolve="rph2" />
+                    </node>
+                    <node concept="liA8E" id="h4X9S9l9Q" role="2OqNvi">
+                      <ref role="37wK5l" to="o3n2:5iAPpylXscy" resolve="makeRelative" />
+                      <node concept="Xl_RD" id="h4X9S9l9R" role="37wK5m">
+                        <property role="Xl_RC" value="/a/b/c/d" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+              <node concept="3clFbF" id="h4X9S9l9S" role="3cqZAp">
+                <node concept="2YIFZM" id="h4X9S9l9T" role="3clFbG">
+                  <ref role="37wK5l" to="rjhg:~Assert.assertEquals(java.lang.Object,java.lang.Object)" resolve="assertEquals" />
+                  <ref role="1Pybhc" to="rjhg:~Assert" resolve="Assert" />
+                  <node concept="Xl_RD" id="h4X9S9l9U" role="37wK5m">
+                    <property role="Xl_RC" value="c/d/" />
+                  </node>
+                  <node concept="2OqwBi" id="h4X9S9l9V" role="37wK5m">
+                    <node concept="37vLTw" id="h4X9S9l9W" role="2Oq$k0">
+                      <ref role="3cqZAo" node="h4X9S9jzo" resolve="rph2" />
+                    </node>
+                    <node concept="liA8E" id="h4X9S9l9X" role="2OqNvi">
+                      <ref role="37wK5l" to="o3n2:5iAPpylXscy" resolve="makeRelative" />
+                      <node concept="Xl_RD" id="h4X9S9l9Y" role="37wK5m">
+                        <property role="Xl_RC" value="/a/b/c/d/" />
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3s$Bmu" id="h4X9SiZ_r" role="3s_gse">
+        <property role="3s$Bm0" value="noCommonPart" />
+        <node concept="3cqZAl" id="h4X9SiZ_s" role="3clF45" />
+        <node concept="3Tm1VV" id="h4X9SiZ_t" role="1B3o_S" />
+        <node concept="3clFbS" id="h4X9SiZ_u" role="3clF47">
+          <node concept="3clFbF" id="h4X9Sk98j" role="3cqZAp">
+            <node concept="2YIFZM" id="h4X9Sk98k" role="3clFbG">
+              <ref role="37wK5l" to="rjhg:~Assert.assertEquals(java.lang.Object,java.lang.Object)" resolve="assertEquals" />
+              <ref role="1Pybhc" to="rjhg:~Assert" resolve="Assert" />
+              <node concept="Xl_RD" id="h4X9Sk98l" role="37wK5m">
+                <property role="Xl_RC" value="../../c/d" />
+              </node>
+              <node concept="2OqwBi" id="h4X9Sk98m" role="37wK5m">
+                <node concept="liA8E" id="h4X9Sk98o" role="2OqNvi">
+                  <ref role="37wK5l" to="o3n2:5iAPpylXscy" resolve="makeRelative" />
+                  <node concept="Xl_RD" id="h4X9Sk98p" role="37wK5m">
+                    <property role="Xl_RC" value="/c/d" />
+                  </node>
+                </node>
+                <node concept="2ShNRf" id="h4X9Skpo_" role="2Oq$k0">
+                  <node concept="1pGfFk" id="h4X9Skq5$" role="2ShVmc">
+                    <property role="373rjd" value="true" />
+                    <ref role="37wK5l" to="o3n2:1AfwOXhIBBI" resolve="RelativePathHelper" />
+                    <node concept="Xl_RD" id="h4X9Skqdk" role="37wK5m">
+                      <property role="Xl_RC" value="/a/b" />
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbF" id="h4X9Sj1jj" role="3cqZAp">
+            <node concept="2YIFZM" id="h4X9Sj1Df" role="3clFbG">
+              <ref role="37wK5l" to="rjhg:~Assert.assertThrows(java.lang.Class,org.junit.function.ThrowingRunnable)" resolve="assertThrows" />
+              <ref role="1Pybhc" to="rjhg:~Assert" resolve="Assert" />
+              <node concept="3VsKOn" id="h4X9Sj1OZ" role="37wK5m">
+                <ref role="3VsUkX" to="o3n2:1AfwOXhIPFt" resolve="PathException" />
+              </node>
+              <node concept="1bVj0M" id="h4X9Sj21z" role="37wK5m">
+                <node concept="3clFbS" id="h4X9Sj21_" role="1bW5cS">
+                  <node concept="3clFbF" id="h4X9Sj3XG" role="3cqZAp">
+                    <node concept="2OqwBi" id="h4X9Sj45k" role="3clFbG">
+                      <node concept="liA8E" id="h4X9Sj4rA" role="2OqNvi">
+                        <ref role="37wK5l" to="o3n2:5iAPpylXscy" resolve="makeRelative" />
+                        <node concept="Xl_RD" id="h4X9Sj4Dv" role="37wK5m">
+                          <property role="Xl_RC" value="/c/d" />
+                        </node>
+                      </node>
+                      <node concept="2ShNRf" id="h4X9Sj0r5" role="2Oq$k0">
+                        <node concept="1pGfFk" id="h4X9Sj14x" role="2ShVmc">
+                          <property role="373rjd" value="true" />
+                          <ref role="37wK5l" to="o3n2:1AfwOXhIBBI" resolve="RelativePathHelper" />
+                          <node concept="Xl_RD" id="h4X9Sj18G" role="37wK5m">
+                            <property role="Xl_RC" value="a/b" />
+                          </node>
+                        </node>
+                      </node>
+                    </node>
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+        </node>
+      </node>
+      <node concept="3s$Bmu" id="h4X9SaPGv" role="3s_gse">
+        <property role="3s$Bm0" value="backslashes" />
+        <node concept="3cqZAl" id="h4X9SaPGw" role="3clF45" />
+        <node concept="3Tm1VV" id="h4X9SaPGx" role="1B3o_S" />
+        <node concept="3clFbS" id="h4X9SaPGy" role="3clF47">
+          <node concept="3cpWs8" id="h4X9SaQm5" role="3cqZAp">
+            <node concept="3cpWsn" id="h4X9SaQm6" role="3cpWs9">
+              <property role="TrG5h" value="rph" />
+              <node concept="3uibUv" id="h4X9SaQm7" role="1tU5fm">
+                <ref role="3uigEE" to="o3n2:5iAPpylXsc4" resolve="RelativePathHelper" />
+              </node>
+              <node concept="2ShNRf" id="h4X9SaQm8" role="33vP2m">
+                <node concept="1pGfFk" id="h4X9SaQm9" role="2ShVmc">
+                  <property role="373rjd" value="true" />
+                  <ref role="37wK5l" to="o3n2:1AfwOXhIBBI" resolve="RelativePathHelper" />
+                  <node concept="Xl_RD" id="h4X9SaQma" role="37wK5m">
+                    <property role="Xl_RC" value="a\\b" />
+                  </node>
+                </node>
+              </node>
+            </node>
+          </node>
+          <node concept="3clFbH" id="h4X9SaQmh" role="3cqZAp" />
+          <node concept="3clFbF" id="h4X9SaQmi" role="3cqZAp">
+            <node concept="2YIFZM" id="h4X9SaQmj" role="3clFbG">
+              <ref role="37wK5l" to="rjhg:~Assert.assertEquals(java.lang.Object,java.lang.Object)" resolve="assertEquals" />
+              <ref role="1Pybhc" to="rjhg:~Assert" resolve="Assert" />
+              <node concept="Xl_RD" id="h4X9SaQmk" role="37wK5m">
+                <property role="Xl_RC" value="c/d" />
+              </node>
+              <node concept="2OqwBi" id="h4X9SaQml" role="37wK5m">
+                <node concept="37vLTw" id="h4X9SaQmm" role="2Oq$k0">
+                  <ref role="3cqZAo" node="h4X9SaQm6" resolve="rph" />
+                </node>
+                <node concept="liA8E" id="h4X9SaQmn" role="2OqNvi">
+                  <ref role="37wK5l" to="o3n2:5iAPpylXscy" resolve="makeRelative" />
+                  <node concept="Xl_RD" id="h4X9SaQmo" role="37wK5m">
+                    <property role="Xl_RC" value="a\\b\\c\\d" />
                   </node>
                 </node>
               </node>

--- a/plugins/mps-build/test/jetbrains.mps.build.tests/test_gen.caches/jetbrains/mps/build/tests/generated
+++ b/plugins/mps-build/test/jetbrains.mps.build.tests/test_gen.caches/jetbrains/mps/build/tests/generated
@@ -1,5 +1,5 @@
 <?xml version="1.0" encoding="UTF-8"?>
-<product version="3" modelHash="3wzykc91lmyz5p1thy9mj0uq4hfp0ih">
+<product version="3" modelHash="-7i0ru3dgkf6o9zygvca74jen3pv48l4">
   <files names="MacroTest_Test.java:TestContext.java:TestRelativePathHelper_Test.java:TestTemporalPaths_Test.java" />
 </product>
 

--- a/plugins/mps-build/test/jetbrains.mps.build.tests/test_gen/jetbrains/mps/build/tests/TestRelativePathHelper_Test.java
+++ b/plugins/mps-build/test/jetbrains.mps.build.tests/test_gen/jetbrains/mps/build/tests/TestRelativePathHelper_Test.java
@@ -43,6 +43,32 @@ public class TestRelativePathHelper_Test {
     Assert.assertEquals(oneUp.replace("\\", "/"), new RelativePathHelper(scriptsFolder).makeAbsolute("../"));
   }
   @Test
+  public void test_dots() throws Exception {
+    {
+      RelativePathHelper rph = new RelativePathHelper("/root/./a/./b/../..");
+      Assert.assertEquals("a/b", rph.makeRelative("/root/a/b"));
+      Assert.assertEquals("c/d/", rph.makeRelative("/root/c/d/"));
+      Assert.assertEquals("c/d/", rph.makeRelative("/root/c/./e/../d/./"));
+    }
+
+    {
+      RelativePathHelper rph = new RelativePathHelper("/a/b/c/d/../..");
+      Assert.assertEquals("c/d", rph.makeRelative("/a/b/c/d"));
+      Assert.assertEquals("c/d/", rph.makeRelative("/a/b/c/d/"));
+    }
+  }
+  @Test
+  public void test_noCommonPart() throws Exception {
+    Assert.assertEquals("../../c/d", new RelativePathHelper("/a/b").makeRelative("/c/d"));
+    Assert.assertThrows(RelativePathHelper.PathException.class, () -> new RelativePathHelper("a/b").makeRelative("/c/d"));
+  }
+  @Test
+  public void test_backslashes() throws Exception {
+    RelativePathHelper rph = new RelativePathHelper("a\\b");
+
+    Assert.assertEquals("c/d", rph.makeRelative("a\\b\\c\\d"));
+  }
+  @Test
   public void test_nonExistentPath() throws Exception {
     // rph assumes its initial path is directory, i.e. "someFolder/"
     RelativePathHelper rph = new RelativePathHelper("common-root/build/someFolder");

--- a/plugins/mps-build/test/jetbrains.mps.build.tests/test_gen/jetbrains/mps/build/tests/trace.info
+++ b/plugins/mps-build/test/jetbrains.mps.build.tests/test_gen/jetbrains/mps/build/tests/trace.info
@@ -1,5 +1,6 @@
 <?xml version="1.0" encoding="UTF-8"?>
 <debug-info version="2">
+  <concept fqn="c:f3061a53-9226-4cc5-a443-f952ceaf5816/1082485599095:jetbrains.mps.baseLanguage.structure.BlockStatement" />
   <concept fqn="c:f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123140:jetbrains.mps.baseLanguage.structure.ConstructorDeclaration" />
   <concept fqn="c:f3061a53-9226-4cc5-a443-f952ceaf5816/1068580123155:jetbrains.mps.baseLanguage.structure.ExpressionStatement" />
   <concept fqn="c:f3061a53-9226-4cc5-a443-f952ceaf5816/1068390468200:jetbrains.mps.baseLanguage.structure.FieldDeclaration" />
@@ -13,70 +14,70 @@
   <concept fqn="c:f3061a53-9226-4cc5-a443-f952ceaf5816/1164991038168:jetbrains.mps.baseLanguage.structure.ThrowStatement" />
   <root nodeRef="r:361d93bd-9223-4768-9e37-bcd7b8db1f40(jetbrains.mps.build.tests@tests)/193602448594327346">
     <file name="MacroTest_Test.java">
-      <node id="193602448594327346" at="23,27,24,25" concept="9" />
-      <node id="6593006940411759671" at="28,51,29,42" concept="1" />
-      <node id="6593006940411759677" at="32,70,33,61" concept="1" />
-      <node id="763409143595611370" at="36,54,37,45" concept="1" />
-      <node id="6593006940411759683" at="40,56,41,47" concept="1" />
-      <node id="384280137912212777" at="44,66,45,57" concept="1" />
-      <node id="384280137912153769" at="48,71,49,62" concept="1" />
-      <node id="384280137912158402" at="52,66,53,57" concept="1" />
-      <node id="193602448594327346" at="58,52,59,19" concept="9" />
-      <node id="193602448594327347" at="63,30,64,42" concept="1" />
-      <node id="763409143595572699" at="64,42,65,42" concept="1" />
-      <node id="384280137912153748" at="65,42,66,42" concept="1" />
-      <node id="6593006940411759671" at="67,9,68,299" concept="1" />
-      <node id="193602448594327347" at="71,30,72,42" concept="1" />
-      <node id="763409143595572699" at="72,42,73,42" concept="1" />
-      <node id="384280137912153748" at="73,42,74,42" concept="1" />
-      <node id="6593006940411759677" at="75,9,76,300" concept="1" />
-      <node id="193602448594327347" at="79,30,80,42" concept="1" />
-      <node id="763409143595572699" at="80,42,81,42" concept="1" />
-      <node id="384280137912153748" at="81,42,82,42" concept="1" />
-      <node id="763409143595611370" at="83,9,84,300" concept="1" />
-      <node id="193602448594327347" at="87,30,88,42" concept="1" />
-      <node id="763409143595572699" at="88,42,89,42" concept="1" />
-      <node id="384280137912153748" at="89,42,90,42" concept="1" />
-      <node id="6593006940411759686" at="92,30,93,278" concept="1" />
-      <node id="6593006940411791715" at="93,278,94,278" concept="1" />
-      <node id="193602448594327347" at="98,30,99,42" concept="1" />
-      <node id="763409143595572699" at="99,42,100,42" concept="1" />
-      <node id="384280137912153748" at="100,42,101,42" concept="1" />
-      <node id="384280137912212777" at="102,9,103,299" concept="1" />
-      <node id="193602448594327347" at="106,30,107,42" concept="1" />
-      <node id="763409143595572699" at="107,42,108,42" concept="1" />
-      <node id="384280137912153748" at="108,42,109,42" concept="1" />
-      <node id="384280137912153769" at="110,9,111,300" concept="1" />
-      <node id="193602448594327347" at="114,30,115,42" concept="1" />
-      <node id="763409143595572699" at="115,42,116,42" concept="1" />
-      <node id="384280137912153748" at="116,42,117,42" concept="1" />
-      <node id="384280137912158402" at="118,9,119,299" concept="1" />
-      <node id="193602448594327346" at="125,0,126,0" concept="8" trace="BuildMacro$qd" />
-      <node id="193602448594327346" at="20,0,22,0" concept="8" trace="ourParamCache" />
-      <node id="193602448594327346" at="23,0,26,0" concept="0" trace="MacroTest_Test#()V" />
-      <node id="193602448594327346" at="58,0,61,0" concept="0" trace="TestBody#(Ljetbrains/mps/lang/test/runtime/TransformationTest;)V" />
-      <node id="6593006940411759671" at="27,0,31,0" concept="3" trace="test_normalScope#()V" />
-      <node id="6593006940411759677" at="31,0,35,0" concept="3" trace="test_onlySeePreviouslyDeclaredMacro#()V" />
-      <node id="763409143595611370" at="35,0,39,0" concept="3" trace="test_doNotSeeItsefl#()V" />
-      <node id="6593006940411759683" at="39,0,43,0" concept="3" trace="test_doNotSeeImported#()V" />
-      <node id="384280137912212777" at="43,0,47,0" concept="3" trace="test_seeImportedVariableInScope#()V" />
-      <node id="384280137912153769" at="47,0,51,0" concept="3" trace="test_doNotSeeForwardVariabletInScope#()V" />
-      <node id="384280137912158402" at="51,0,55,0" concept="3" trace="test_seeBackwardVariableInScope#()V" />
-      <node id="6593006940411759683" at="91,9,95,9" concept="1" />
-      <node id="6593006940411759671" at="62,53,67,9" concept="1" />
-      <node id="6593006940411759677" at="70,72,75,9" concept="1" />
-      <node id="763409143595611370" at="78,56,83,9" concept="1" />
-      <node id="6593006940411759683" at="86,58,91,9" concept="1" />
-      <node id="384280137912212777" at="97,68,102,9" concept="1" />
-      <node id="384280137912153769" at="105,73,110,9" concept="1" />
-      <node id="384280137912158402" at="113,68,118,9" concept="1" />
-      <node id="6593006940411759671" at="62,0,70,0" concept="3" trace="test_normalScope#()V" />
-      <node id="6593006940411759677" at="70,0,78,0" concept="3" trace="test_onlySeePreviouslyDeclaredMacro#()V" />
-      <node id="763409143595611370" at="78,0,86,0" concept="3" trace="test_doNotSeeItsefl#()V" />
-      <node id="384280137912212777" at="97,0,105,0" concept="3" trace="test_seeImportedVariableInScope#()V" />
-      <node id="384280137912153769" at="105,0,113,0" concept="3" trace="test_doNotSeeForwardVariabletInScope#()V" />
-      <node id="384280137912158402" at="113,0,121,0" concept="3" trace="test_seeBackwardVariableInScope#()V" />
-      <node id="6593006940411759683" at="86,0,97,0" concept="3" trace="test_doNotSeeImported#()V" />
+      <node id="193602448594327346" at="23,27,24,25" concept="10" />
+      <node id="6593006940411759671" at="28,51,29,42" concept="2" />
+      <node id="6593006940411759677" at="32,70,33,61" concept="2" />
+      <node id="763409143595611370" at="36,54,37,45" concept="2" />
+      <node id="6593006940411759683" at="40,56,41,47" concept="2" />
+      <node id="384280137912212777" at="44,66,45,57" concept="2" />
+      <node id="384280137912153769" at="48,71,49,62" concept="2" />
+      <node id="384280137912158402" at="52,66,53,57" concept="2" />
+      <node id="193602448594327346" at="58,52,59,19" concept="10" />
+      <node id="193602448594327347" at="63,30,64,42" concept="2" />
+      <node id="763409143595572699" at="64,42,65,42" concept="2" />
+      <node id="384280137912153748" at="65,42,66,42" concept="2" />
+      <node id="6593006940411759671" at="67,9,68,299" concept="2" />
+      <node id="193602448594327347" at="71,30,72,42" concept="2" />
+      <node id="763409143595572699" at="72,42,73,42" concept="2" />
+      <node id="384280137912153748" at="73,42,74,42" concept="2" />
+      <node id="6593006940411759677" at="75,9,76,300" concept="2" />
+      <node id="193602448594327347" at="79,30,80,42" concept="2" />
+      <node id="763409143595572699" at="80,42,81,42" concept="2" />
+      <node id="384280137912153748" at="81,42,82,42" concept="2" />
+      <node id="763409143595611370" at="83,9,84,300" concept="2" />
+      <node id="193602448594327347" at="87,30,88,42" concept="2" />
+      <node id="763409143595572699" at="88,42,89,42" concept="2" />
+      <node id="384280137912153748" at="89,42,90,42" concept="2" />
+      <node id="6593006940411759686" at="92,30,93,278" concept="2" />
+      <node id="6593006940411791715" at="93,278,94,278" concept="2" />
+      <node id="193602448594327347" at="98,30,99,42" concept="2" />
+      <node id="763409143595572699" at="99,42,100,42" concept="2" />
+      <node id="384280137912153748" at="100,42,101,42" concept="2" />
+      <node id="384280137912212777" at="102,9,103,299" concept="2" />
+      <node id="193602448594327347" at="106,30,107,42" concept="2" />
+      <node id="763409143595572699" at="107,42,108,42" concept="2" />
+      <node id="384280137912153748" at="108,42,109,42" concept="2" />
+      <node id="384280137912153769" at="110,9,111,300" concept="2" />
+      <node id="193602448594327347" at="114,30,115,42" concept="2" />
+      <node id="763409143595572699" at="115,42,116,42" concept="2" />
+      <node id="384280137912153748" at="116,42,117,42" concept="2" />
+      <node id="384280137912158402" at="118,9,119,299" concept="2" />
+      <node id="193602448594327346" at="125,0,126,0" concept="9" trace="BuildMacro$qd" />
+      <node id="193602448594327346" at="20,0,22,0" concept="9" trace="ourParamCache" />
+      <node id="193602448594327346" at="23,0,26,0" concept="1" trace="MacroTest_Test#()V" />
+      <node id="193602448594327346" at="58,0,61,0" concept="1" trace="TestBody#(Ljetbrains/mps/lang/test/runtime/TransformationTest;)V" />
+      <node id="6593006940411759671" at="27,0,31,0" concept="4" trace="test_normalScope#()V" />
+      <node id="6593006940411759677" at="31,0,35,0" concept="4" trace="test_onlySeePreviouslyDeclaredMacro#()V" />
+      <node id="763409143595611370" at="35,0,39,0" concept="4" trace="test_doNotSeeItsefl#()V" />
+      <node id="6593006940411759683" at="39,0,43,0" concept="4" trace="test_doNotSeeImported#()V" />
+      <node id="384280137912212777" at="43,0,47,0" concept="4" trace="test_seeImportedVariableInScope#()V" />
+      <node id="384280137912153769" at="47,0,51,0" concept="4" trace="test_doNotSeeForwardVariabletInScope#()V" />
+      <node id="384280137912158402" at="51,0,55,0" concept="4" trace="test_seeBackwardVariableInScope#()V" />
+      <node id="6593006940411759683" at="91,9,95,9" concept="2" />
+      <node id="6593006940411759671" at="62,53,67,9" concept="2" />
+      <node id="6593006940411759677" at="70,72,75,9" concept="2" />
+      <node id="763409143595611370" at="78,56,83,9" concept="2" />
+      <node id="6593006940411759683" at="86,58,91,9" concept="2" />
+      <node id="384280137912212777" at="97,68,102,9" concept="2" />
+      <node id="384280137912153769" at="105,73,110,9" concept="2" />
+      <node id="384280137912158402" at="113,68,118,9" concept="2" />
+      <node id="6593006940411759671" at="62,0,70,0" concept="4" trace="test_normalScope#()V" />
+      <node id="6593006940411759677" at="70,0,78,0" concept="4" trace="test_onlySeePreviouslyDeclaredMacro#()V" />
+      <node id="763409143595611370" at="78,0,86,0" concept="4" trace="test_doNotSeeItsefl#()V" />
+      <node id="384280137912212777" at="97,0,105,0" concept="4" trace="test_seeImportedVariableInScope#()V" />
+      <node id="384280137912153769" at="105,0,113,0" concept="4" trace="test_doNotSeeForwardVariabletInScope#()V" />
+      <node id="384280137912158402" at="113,0,121,0" concept="4" trace="test_seeBackwardVariableInScope#()V" />
+      <node id="6593006940411759683" at="86,0,97,0" concept="4" trace="test_doNotSeeImported#()V" />
       <scope id="193602448594327346" at="23,27,24,25" />
       <scope id="6593006940411759671" at="28,51,29,42" />
       <scope id="6593006940411759677" at="32,70,33,61" />
@@ -126,49 +127,49 @@
   </root>
   <root nodeRef="r:361d93bd-9223-4768-9e37-bcd7b8db1f40(jetbrains.mps.build.tests@tests)/4045247515868358877">
     <file name="TestTemporalPaths_Test.java">
-      <node id="4045247515868358877" at="22,35,23,25" concept="9" />
-      <node id="4045247515868358881" at="27,51,28,42" concept="1" />
-      <node id="8104754176559709905" at="31,54,32,45" concept="1" />
-      <node id="7422876504327290553" at="35,57,36,48" concept="1" />
-      <node id="280273048052535301" at="39,51,40,42" concept="1" />
-      <node id="8104754176559709912" at="43,51,44,42" concept="1" />
-      <node id="4209004860870558820" at="47,55,48,46" concept="1" />
-      <node id="4045247515868358877" at="53,52,54,19" concept="9" />
-      <node id="4045247515868358881" at="57,53,58,65" concept="1" />
-      <node id="4045247515868358881" at="58,65,59,264" concept="1" />
-      <node id="8104754176559709905" at="61,56,62,65" concept="1" />
-      <node id="8104754176559709905" at="62,65,63,262" concept="1" />
-      <node id="7422876504327290553" at="65,59,66,65" concept="1" />
-      <node id="7422876504327290553" at="66,65,67,272" concept="1" />
-      <node id="280273048052535301" at="69,53,70,65" concept="1" />
-      <node id="280273048052535301" at="70,65,71,271" concept="1" />
-      <node id="8104754176559709912" at="73,53,74,65" concept="1" />
-      <node id="4209004860870549128" at="75,30,76,86" concept="4" />
-      <node id="8104754176559709915" at="76,86,77,224" concept="1" />
-      <node id="8104754176559709940" at="77,224,78,240" concept="1" />
-      <node id="4209004860870558820" at="81,57,82,65" concept="1" />
-      <node id="4209004860870558823" at="83,30,84,86" concept="4" />
-      <node id="4209004860870558828" at="84,86,85,220" concept="1" />
-      <node id="4209004860870558836" at="85,220,86,221" concept="1" />
-      <node id="1029938204559747214" at="90,40,91,176" concept="5" />
-      <node id="4045247515868358877" at="19,0,21,0" concept="8" trace="ourParamCache" />
-      <node id="4045247515868358877" at="22,0,25,0" concept="0" trace="TestTemporalPaths_Test#()V" />
-      <node id="4045247515868358877" at="53,0,56,0" concept="0" trace="TestBody#(Ljetbrains/mps/lang/test/runtime/TransformationTest;)V" />
-      <node id="1029938204559746995" at="90,0,93,0" concept="3" trace="getBuildTestsModel#()Lorg/jetbrains/mps/openapi/model/SModel;" />
-      <node id="4045247515868358881" at="26,0,30,0" concept="3" trace="test_topLevelJar#()V" />
-      <node id="8104754176559709905" at="30,0,34,0" concept="3" trace="test_topLevelFolder#()V" />
-      <node id="7422876504327290553" at="34,0,38,0" concept="3" trace="test_topInternalFolder#()V" />
-      <node id="280273048052535301" at="38,0,42,0" concept="3" trace="test_jarInFolder#()V" />
-      <node id="8104754176559709912" at="42,0,46,0" concept="3" trace="test_folderInJar#()V" />
-      <node id="4209004860870558820" at="46,0,50,0" concept="3" trace="test_duplicatedNames#()V" />
-      <node id="4045247515868358881" at="57,0,61,0" concept="3" trace="test_topLevelJar#()V" />
-      <node id="8104754176559709905" at="61,0,65,0" concept="3" trace="test_topLevelFolder#()V" />
-      <node id="7422876504327290553" at="65,0,69,0" concept="3" trace="test_topInternalFolder#()V" />
-      <node id="280273048052535301" at="69,0,73,0" concept="3" trace="test_jarInFolder#()V" />
-      <node id="8104754176559709912" at="74,65,79,9" concept="1" />
-      <node id="4209004860870558820" at="82,65,87,9" concept="1" />
-      <node id="8104754176559709912" at="73,0,81,0" concept="3" trace="test_folderInJar#()V" />
-      <node id="4209004860870558820" at="81,0,89,0" concept="3" trace="test_duplicatedNames#()V" />
+      <node id="4045247515868358877" at="22,35,23,25" concept="10" />
+      <node id="4045247515868358881" at="27,51,28,42" concept="2" />
+      <node id="8104754176559709905" at="31,54,32,45" concept="2" />
+      <node id="7422876504327290553" at="35,57,36,48" concept="2" />
+      <node id="280273048052535301" at="39,51,40,42" concept="2" />
+      <node id="8104754176559709912" at="43,51,44,42" concept="2" />
+      <node id="4209004860870558820" at="47,55,48,46" concept="2" />
+      <node id="4045247515868358877" at="53,52,54,19" concept="10" />
+      <node id="4045247515868358881" at="57,53,58,65" concept="2" />
+      <node id="4045247515868358881" at="58,65,59,264" concept="2" />
+      <node id="8104754176559709905" at="61,56,62,65" concept="2" />
+      <node id="8104754176559709905" at="62,65,63,262" concept="2" />
+      <node id="7422876504327290553" at="65,59,66,65" concept="2" />
+      <node id="7422876504327290553" at="66,65,67,272" concept="2" />
+      <node id="280273048052535301" at="69,53,70,65" concept="2" />
+      <node id="280273048052535301" at="70,65,71,271" concept="2" />
+      <node id="8104754176559709912" at="73,53,74,65" concept="2" />
+      <node id="4209004860870549128" at="75,30,76,86" concept="5" />
+      <node id="8104754176559709915" at="76,86,77,224" concept="2" />
+      <node id="8104754176559709940" at="77,224,78,240" concept="2" />
+      <node id="4209004860870558820" at="81,57,82,65" concept="2" />
+      <node id="4209004860870558823" at="83,30,84,86" concept="5" />
+      <node id="4209004860870558828" at="84,86,85,220" concept="2" />
+      <node id="4209004860870558836" at="85,220,86,221" concept="2" />
+      <node id="1029938204559747214" at="90,40,91,176" concept="6" />
+      <node id="4045247515868358877" at="19,0,21,0" concept="9" trace="ourParamCache" />
+      <node id="4045247515868358877" at="22,0,25,0" concept="1" trace="TestTemporalPaths_Test#()V" />
+      <node id="4045247515868358877" at="53,0,56,0" concept="1" trace="TestBody#(Ljetbrains/mps/lang/test/runtime/TransformationTest;)V" />
+      <node id="1029938204559746995" at="90,0,93,0" concept="4" trace="getBuildTestsModel#()Lorg/jetbrains/mps/openapi/model/SModel;" />
+      <node id="4045247515868358881" at="26,0,30,0" concept="4" trace="test_topLevelJar#()V" />
+      <node id="8104754176559709905" at="30,0,34,0" concept="4" trace="test_topLevelFolder#()V" />
+      <node id="7422876504327290553" at="34,0,38,0" concept="4" trace="test_topInternalFolder#()V" />
+      <node id="280273048052535301" at="38,0,42,0" concept="4" trace="test_jarInFolder#()V" />
+      <node id="8104754176559709912" at="42,0,46,0" concept="4" trace="test_folderInJar#()V" />
+      <node id="4209004860870558820" at="46,0,50,0" concept="4" trace="test_duplicatedNames#()V" />
+      <node id="4045247515868358881" at="57,0,61,0" concept="4" trace="test_topLevelJar#()V" />
+      <node id="8104754176559709905" at="61,0,65,0" concept="4" trace="test_topLevelFolder#()V" />
+      <node id="7422876504327290553" at="65,0,69,0" concept="4" trace="test_topInternalFolder#()V" />
+      <node id="280273048052535301" at="69,0,73,0" concept="4" trace="test_jarInFolder#()V" />
+      <node id="8104754176559709912" at="74,65,79,9" concept="2" />
+      <node id="4209004860870558820" at="82,65,87,9" concept="2" />
+      <node id="8104754176559709912" at="73,0,81,0" concept="4" trace="test_folderInJar#()V" />
+      <node id="4209004860870558820" at="81,0,89,0" concept="4" trace="test_duplicatedNames#()V" />
       <scope id="4045247515868358877" at="22,35,23,25" />
       <scope id="4045247515868358881" at="27,51,28,42" />
       <scope id="8104754176559709905" at="31,54,32,45" />
@@ -213,58 +214,90 @@
   </root>
   <root nodeRef="r:361d93bd-9223-4768-9e37-bcd7b8db1f40(jetbrains.mps.build.tests@tests)/5368511706901688070">
     <file name="TestRelativePathHelper_Test.java">
-      <node id="1841835149314679084" at="12,52,13,70" concept="4" />
-      <node id="1841835149314679092" at="13,70,14,21" concept="1" />
-      <node id="1841835149314679120" at="14,21,15,21" concept="1" />
-      <node id="1841835149314679148" at="15,21,16,27" concept="1" />
-      <node id="1841835149314679176" at="16,27,17,0" concept="7" />
-      <node id="1841835149314687007" at="17,0,18,54" concept="4" />
-      <node id="1841835149314687032" at="18,54,19,21" concept="1" />
-      <node id="1841835149314687027" at="19,21,20,0" concept="7" />
-      <node id="1841835149314690704" at="20,0,21,14" concept="6" />
-      <node id="1841835149314679293" at="21,14,22,54" concept="4" />
-      <node id="1841835149314680236" at="22,54,23,73" concept="4" />
-      <node id="1841835149314686956" at="23,73,24,0" concept="7" />
-      <node id="1841835149314679310" at="24,0,25,106" concept="1" />
-      <node id="1841835149314690696" at="25,106,26,0" concept="7" />
-      <node id="1841835149314690707" at="26,0,27,11" concept="6" />
-      <node id="1841835149314690709" at="27,11,28,125" concept="1" />
-      <node id="1841835149314781642" at="28,125,29,126" concept="1" />
-      <node id="1841835149314778424" at="29,126,30,0" concept="7" />
-      <node id="1841835149314778430" at="30,0,31,20" concept="6" />
-      <node id="1841835149314778443" at="31,20,32,95" concept="1" />
-      <node id="1841835149314778438" at="32,95,33,0" concept="7" />
-      <node id="1841835149314778510" at="33,0,34,11" concept="6" />
-      <node id="1841835149314778484" at="34,11,35,135" concept="1" />
-      <node id="1841835149314778477" at="35,135,36,0" concept="7" />
-      <node id="1841835149314779974" at="36,0,37,21" concept="6" />
-      <node id="1841835149314780163" at="37,21,38,62" concept="4" />
-      <node id="1841835149314779994" at="38,62,39,89" concept="1" />
-      <node id="1841835149314780116" at="39,89,40,0" concept="7" />
-      <node id="1841835149314780128" at="40,0,41,11" concept="6" />
-      <node id="1841835149314780130" at="41,11,42,108" concept="1" />
-      <node id="1841835149314781674" at="42,108,43,109" concept="1" />
-      <node id="3913486790554958313" at="46,55,47,68" concept="6" />
-      <node id="3913486790554846817" at="47,68,48,84" concept="4" />
-      <node id="3913486790555024852" at="48,84,49,97" concept="6" />
-      <node id="3913486790554879562" at="49,97,50,59" concept="4" />
-      <node id="3913486790554884371" at="50,59,51,60" concept="4" />
-      <node id="3913486790554898054" at="51,60,52,48" concept="1" />
-      <node id="3913486790554924646" at="52,48,53,49" concept="1" />
-      <node id="3913486790555818473" at="53,49,54,65" concept="4" />
-      <node id="3913486790555839089" at="54,65,55,66" concept="4" />
-      <node id="3913486790555810440" at="55,66,56,32" concept="1" />
-      <node id="3913486790555847264" at="56,32,57,32" concept="1" />
-      <node id="3913486790554806816" at="45,0,59,0" concept="3" trace="test_nonExistentPath#()V" />
-      <node id="5368511706901692172" at="11,0,45,0" concept="3" trace="test_testRelPaths#()V" />
-      <scope id="3913486790554806819" at="46,55,57,32">
+      <node id="1841835149314679084" at="12,52,13,70" concept="5" />
+      <node id="1841835149314679092" at="13,70,14,21" concept="2" />
+      <node id="1841835149314679120" at="14,21,15,21" concept="2" />
+      <node id="1841835149314679148" at="15,21,16,27" concept="2" />
+      <node id="1841835149314679176" at="16,27,17,0" concept="8" />
+      <node id="1841835149314687007" at="17,0,18,54" concept="5" />
+      <node id="1841835149314687032" at="18,54,19,21" concept="2" />
+      <node id="1841835149314687027" at="19,21,20,0" concept="8" />
+      <node id="1841835149314690704" at="20,0,21,14" concept="7" />
+      <node id="1841835149314679293" at="21,14,22,54" concept="5" />
+      <node id="1841835149314680236" at="22,54,23,73" concept="5" />
+      <node id="1841835149314686956" at="23,73,24,0" concept="8" />
+      <node id="1841835149314679310" at="24,0,25,106" concept="2" />
+      <node id="1841835149314690696" at="25,106,26,0" concept="8" />
+      <node id="1841835149314690707" at="26,0,27,11" concept="7" />
+      <node id="1841835149314690709" at="27,11,28,125" concept="2" />
+      <node id="1841835149314781642" at="28,125,29,126" concept="2" />
+      <node id="1841835149314778424" at="29,126,30,0" concept="8" />
+      <node id="1841835149314778430" at="30,0,31,20" concept="7" />
+      <node id="1841835149314778443" at="31,20,32,95" concept="2" />
+      <node id="1841835149314778438" at="32,95,33,0" concept="8" />
+      <node id="1841835149314778510" at="33,0,34,11" concept="7" />
+      <node id="1841835149314778484" at="34,11,35,135" concept="2" />
+      <node id="1841835149314778477" at="35,135,36,0" concept="8" />
+      <node id="1841835149314779974" at="36,0,37,21" concept="7" />
+      <node id="1841835149314780163" at="37,21,38,62" concept="5" />
+      <node id="1841835149314779994" at="38,62,39,89" concept="2" />
+      <node id="1841835149314780116" at="39,89,40,0" concept="8" />
+      <node id="1841835149314780128" at="40,0,41,11" concept="7" />
+      <node id="1841835149314780130" at="41,11,42,108" concept="2" />
+      <node id="1841835149314781674" at="42,108,43,109" concept="2" />
+      <node id="4806869282852365" at="47,5,48,77" concept="5" />
+      <node id="4806869282862346" at="48,77,49,64" concept="2" />
+      <node id="4806869283679171" at="49,64,50,66" concept="2" />
+      <node id="4806869286011130" at="50,66,51,75" concept="2" />
+      <node id="4806869283844724" at="52,5,53,0" concept="8" />
+      <node id="4806869283846359" at="54,5,55,72" concept="5" />
+      <node id="4806869283852913" at="55,72,56,63" concept="2" />
+      <node id="4806869283852920" at="56,63,57,65" concept="2" />
+      <node id="4806869286687251" at="61,52,62,90" concept="2" />
+      <node id="4806869286393043" at="62,90,63,122" concept="2" />
+      <node id="4806869284251013" at="66,51,67,60" concept="5" />
+      <node id="4806869284251025" at="67,60,68,0" concept="8" />
+      <node id="4806869284251026" at="68,0,69,63" concept="2" />
+      <node id="3913486790554958313" at="72,55,73,68" concept="7" />
+      <node id="3913486790554846817" at="73,68,74,84" concept="5" />
+      <node id="3913486790555024852" at="74,84,75,97" concept="7" />
+      <node id="3913486790554879562" at="75,97,76,59" concept="5" />
+      <node id="3913486790554884371" at="76,59,77,60" concept="5" />
+      <node id="3913486790554898054" at="77,60,78,48" concept="2" />
+      <node id="3913486790554924646" at="78,48,79,49" concept="2" />
+      <node id="3913486790555818473" at="79,49,80,65" concept="5" />
+      <node id="3913486790555839089" at="80,65,81,66" concept="5" />
+      <node id="3913486790555810440" at="81,66,82,32" concept="2" />
+      <node id="3913486790555847264" at="82,32,83,32" concept="2" />
+      <node id="4806869284229202" at="53,0,58,5" concept="0" />
+      <node id="4806869286386011" at="60,0,65,0" concept="4" trace="test_noCommonPart#()V" />
+      <node id="4806869284226468" at="46,44,52,5" concept="0" />
+      <node id="4806869284248351" at="65,0,71,0" concept="4" trace="test_backslashes#()V" />
+      <node id="3913486790554806816" at="71,0,85,0" concept="4" trace="test_nonExistentPath#()V" />
+      <node id="4806869282848562" at="45,0,60,0" concept="4" trace="test_dots#()V" />
+      <node id="5368511706901692172" at="11,0,45,0" concept="4" trace="test_testRelPaths#()V" />
+      <scope id="4806869286386014" at="61,52,63,122" />
+      <scope id="4806869284229204" at="54,5,57,65">
+        <var name="rph" id="4806869283846360" />
+      </scope>
+      <scope id="4806869284248354" at="66,51,69,63">
+        <var name="rph" id="4806869284251014" />
+      </scope>
+      <scope id="4806869284226470" at="47,5,51,75">
+        <var name="rph" id="4806869282852366" />
+      </scope>
+      <scope id="4806869286386011" at="60,0,65,0" />
+      <scope id="4806869284248351" at="65,0,71,0" />
+      <scope id="3913486790554806819" at="72,55,83,32">
         <var name="r1" id="3913486790554879563" />
         <var name="r2" id="3913486790554884372" />
         <var name="r3" id="3913486790555818474" />
         <var name="r4" id="3913486790555839090" />
         <var name="rph" id="3913486790554846818" />
       </scope>
-      <scope id="3913486790554806816" at="45,0,59,0" />
+      <scope id="4806869282848565" at="46,44,58,5" />
+      <scope id="3913486790554806816" at="71,0,85,0" />
+      <scope id="4806869282848562" at="45,0,60,0" />
       <scope id="5368511706901692175" at="12,52,43,109">
         <var name="baseDir" id="1841835149314687008" />
         <var name="oneUp" id="1841835149314780164" />
@@ -273,76 +306,76 @@
         <var name="tmpFile" id="1841835149314679085" />
       </scope>
       <scope id="5368511706901692172" at="11,0,45,0" />
-      <unit id="5368511706901688070" at="10,0,60,0" name="jetbrains.mps.build.tests.TestRelativePathHelper_Test" />
+      <unit id="5368511706901688070" at="10,0,86,0" name="jetbrains.mps.build.tests.TestRelativePathHelper_Test" />
     </file>
   </root>
   <root nodeRef="r:361d93bd-9223-4768-9e37-bcd7b8db1f40(jetbrains.mps.build.tests@tests)/5584673629410321146">
     <file name="TestContext.java">
-      <node id="5584673629410321283" at="16,0,17,0" concept="8" trace="TEMP_MACRO" />
-      <node id="193602448594332738" at="17,0,18,0" concept="8" trace="TEMP" />
-      <node id="5584673629410321288" at="18,0,19,0" concept="8" trace="DEPLOY_MACRO" />
-      <node id="193602448594332754" at="19,0,20,0" concept="8" trace="DEPLOY" />
-      <node id="6547494638219647894" at="20,43,21,44" concept="9" />
-      <node id="6547494638219647782" at="25,0,26,0" concept="2" trace="map" />
-      <node id="6547494638219654976" at="26,0,27,0" concept="2" trace="model" />
-      <node id="7439704124700848913" at="27,41,28,14" concept="9" />
-      <node id="6547494638219654979" at="28,14,29,25" concept="1" />
-      <node id="6547494638219647804" at="32,56,33,27" concept="5" />
-      <node id="6547494638219647847" at="36,46,37,24" concept="5" />
-      <node id="6547494638219654990" at="40,57,41,18" concept="5" />
-      <node id="6547494638219654993" at="44,43,45,19" concept="5" />
-      <node id="6547494638219654986" at="48,62,49,48" concept="10" />
-      <node id="6547494638219647670" at="52,44,53,48" concept="10" />
-      <node id="6547494638219647675" at="56,51,57,48" concept="10" />
-      <node id="6547494638219647678" at="60,61,61,48" concept="10" />
-      <node id="6547494638219647681" at="64,63,65,48" concept="10" />
-      <node id="6547494638219647684" at="68,67,69,48" concept="10" />
-      <node id="6547494638219647687" at="72,48,73,48" concept="10" />
-      <node id="6547494638219647690" at="76,64,77,48" concept="10" />
-      <node id="6547494638219647693" at="80,57,81,48" concept="10" />
-      <node id="6547494638219647696" at="84,53,85,48" concept="10" />
-      <node id="6547494638219647699" at="88,46,89,48" concept="10" />
-      <node id="6547494638219647702" at="92,53,93,48" concept="10" />
-      <node id="6547494638219647705" at="96,69,97,48" concept="10" />
-      <node id="6547494638219647711" at="100,63,101,48" concept="10" />
-      <node id="6547494638219647717" at="104,68,105,48" concept="10" />
-      <node id="6547494638219647726" at="108,78,109,48" concept="10" />
-      <node id="6547494638219647729" at="112,95,113,48" concept="10" />
-      <node id="6547494638219647735" at="116,85,117,48" concept="10" />
-      <node id="6547494638219647744" at="120,46,121,48" concept="10" />
-      <node id="6547494638219647753" at="124,36,125,48" concept="10" />
-      <node id="6547494638219647760" at="128,35,129,48" concept="10" />
-      <node id="6547494638219647763" at="132,34,133,48" concept="10" />
-      <node id="6547494638219647769" at="136,33,137,48" concept="10" />
-      <node id="5584673629410321148" at="20,0,23,0" concept="0" trace="TestContext#(Lorg/jetbrains/mps/openapi/model/SModel;)V" />
-      <node id="6547494638219647278" at="27,0,31,0" concept="0" trace="TestGenContext#(Lorg/jetbrains/mps/openapi/model/SModel;)V" />
-      <node id="6547494638219647311" at="31,0,35,0" concept="3" trace="putSessionObject#(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;" />
-      <node id="6547494638219647301" at="35,0,39,0" concept="3" trace="getSessionObject#(Ljava/lang/Object;)Ljava/lang/Object;" />
-      <node id="6547494638219647510" at="39,0,43,0" concept="3" trace="getOriginalCopiedInputNode#(Lorg/jetbrains/mps/openapi/model/SNode;)Lorg/jetbrains/mps/openapi/model/SNode;" />
-      <node id="6547494638219647376" at="43,0,47,0" concept="3" trace="getOriginalInputModel#()Lorg/jetbrains/mps/openapi/model/SModel;" />
-      <node id="6547494638219647490" at="47,0,51,0" concept="3" trace="getCopiedOutputNodeForInputNode#(Lorg/jetbrains/mps/openapi/model/SNode;)Lorg/jetbrains/mps/openapi/model/SNode;" />
-      <node id="6547494638219647662" at="51,0,55,0" concept="3" trace="getRuleNode#()Lorg/jetbrains/mps/openapi/model/SNodeReference;" />
-      <node id="6547494638219647655" at="55,0,59,0" concept="3" trace="getTemplateNodeRef#()Lorg/jetbrains/mps/openapi/model/SNodeReference;" />
-      <node id="6547494638219647642" at="59,0,63,0" concept="3" trace="showErrorMessage#(Lorg/jetbrains/mps/openapi/model/SNode;Ljava/lang/String;)V" />
-      <node id="6547494638219647629" at="63,0,67,0" concept="3" trace="showWarningMessage#(Lorg/jetbrains/mps/openapi/model/SNode;Ljava/lang/String;)V" />
-      <node id="6547494638219647616" at="67,0,71,0" concept="3" trace="showInformationMessage#(Lorg/jetbrains/mps/openapi/model/SNode;Ljava/lang/String;)V" />
-      <node id="6547494638219647606" at="71,0,75,0" concept="3" trace="getStepObject#(Ljava/lang/Object;)Ljava/lang/Object;" />
-      <node id="6547494638219647593" at="75,0,79,0" concept="3" trace="putStepObject#(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;" />
-      <node id="6547494638219647583" at="79,0,83,0" concept="3" trace="getGenerationParameter#(Ljava/lang/String;)Ljava/lang/Object;" />
-      <node id="6547494638219647573" at="83,0,87,0" concept="3" trace="getPatternVariable#(Ljava/lang/String;)Ljava/lang/Object;" />
-      <node id="6547494638219647563" at="87,0,91,0" concept="3" trace="getVariable#(Ljava/lang/String;)Ljava/lang/Object;" />
-      <node id="6547494638219647553" at="91,0,95,0" concept="3" trace="getTransientObject#(Ljava/lang/Object;)Ljava/lang/Object;" />
-      <node id="6547494638219647540" at="95,0,99,0" concept="3" trace="putTransientObject#(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;" />
-      <node id="6547494638219647520" at="99,0,103,0" concept="3" trace="createUniqueName#(Ljava/lang/String;Lorg/jetbrains/mps/openapi/model/SNode;)Ljava/lang/String;" />
-      <node id="6547494638219647500" at="103,0,107,0" concept="3" trace="getPreviousInputNodeByMappingLabel#(Ljava/lang/String;)Lorg/jetbrains/mps/openapi/model/SNode;" />
-      <node id="6547494638219647458" at="107,0,111,0" concept="3" trace="registerMappingLabel#(Lorg/jetbrains/mps/openapi/model/SNode;Ljava/lang/String;Lorg/jetbrains/mps/openapi/model/SNode;)V" />
-      <node id="6547494638219647444" at="111,0,115,0" concept="3" trace="getAllOutputNodesByInputNodeAndMappingLabel#(Lorg/jetbrains/mps/openapi/model/SNode;Ljava/lang/String;)Ljava/util/List;" />
-      <node id="6547494638219647414" at="115,0,119,0" concept="3" trace="getOutputNodeByInputNodeAndMappingLabel#(Lorg/jetbrains/mps/openapi/model/SNode;Ljava/lang/String;)Lorg/jetbrains/mps/openapi/model/SNode;" />
-      <node id="6547494638219647390" at="119,0,123,0" concept="3" trace="getGenerator#()Ljetbrains/mps/generator/template/ITemplateGenerator;" />
-      <node id="6547494638219647369" at="123,0,127,0" concept="3" trace="getOutputModel#()Lorg/jetbrains/mps/openapi/model/SModel;" />
-      <node id="6547494638219647352" at="127,0,131,0" concept="3" trace="getInputModel#()Lorg/jetbrains/mps/openapi/model/SModel;" />
-      <node id="6547494638219647345" at="131,0,135,0" concept="3" trace="getOutputNode#()Lorg/jetbrains/mps/openapi/model/SNode;" />
-      <node id="6547494638219647331" at="135,0,139,0" concept="3" trace="getInputNode#()Lorg/jetbrains/mps/openapi/model/SNode;" />
+      <node id="5584673629410321283" at="16,0,17,0" concept="9" trace="TEMP_MACRO" />
+      <node id="193602448594332738" at="17,0,18,0" concept="9" trace="TEMP" />
+      <node id="5584673629410321288" at="18,0,19,0" concept="9" trace="DEPLOY_MACRO" />
+      <node id="193602448594332754" at="19,0,20,0" concept="9" trace="DEPLOY" />
+      <node id="6547494638219647894" at="20,43,21,44" concept="10" />
+      <node id="6547494638219647782" at="25,0,26,0" concept="3" trace="map" />
+      <node id="6547494638219654976" at="26,0,27,0" concept="3" trace="model" />
+      <node id="7439704124700848913" at="27,41,28,14" concept="10" />
+      <node id="6547494638219654979" at="28,14,29,25" concept="2" />
+      <node id="6547494638219647804" at="32,56,33,27" concept="6" />
+      <node id="6547494638219647847" at="36,46,37,24" concept="6" />
+      <node id="6547494638219654990" at="40,57,41,18" concept="6" />
+      <node id="6547494638219654993" at="44,43,45,19" concept="6" />
+      <node id="6547494638219654986" at="48,62,49,48" concept="11" />
+      <node id="6547494638219647670" at="52,44,53,48" concept="11" />
+      <node id="6547494638219647675" at="56,51,57,48" concept="11" />
+      <node id="6547494638219647678" at="60,61,61,48" concept="11" />
+      <node id="6547494638219647681" at="64,63,65,48" concept="11" />
+      <node id="6547494638219647684" at="68,67,69,48" concept="11" />
+      <node id="6547494638219647687" at="72,48,73,48" concept="11" />
+      <node id="6547494638219647690" at="76,64,77,48" concept="11" />
+      <node id="6547494638219647693" at="80,57,81,48" concept="11" />
+      <node id="6547494638219647696" at="84,53,85,48" concept="11" />
+      <node id="6547494638219647699" at="88,46,89,48" concept="11" />
+      <node id="6547494638219647702" at="92,53,93,48" concept="11" />
+      <node id="6547494638219647705" at="96,69,97,48" concept="11" />
+      <node id="6547494638219647711" at="100,63,101,48" concept="11" />
+      <node id="6547494638219647717" at="104,68,105,48" concept="11" />
+      <node id="6547494638219647726" at="108,78,109,48" concept="11" />
+      <node id="6547494638219647729" at="112,95,113,48" concept="11" />
+      <node id="6547494638219647735" at="116,85,117,48" concept="11" />
+      <node id="6547494638219647744" at="120,46,121,48" concept="11" />
+      <node id="6547494638219647753" at="124,36,125,48" concept="11" />
+      <node id="6547494638219647760" at="128,35,129,48" concept="11" />
+      <node id="6547494638219647763" at="132,34,133,48" concept="11" />
+      <node id="6547494638219647769" at="136,33,137,48" concept="11" />
+      <node id="5584673629410321148" at="20,0,23,0" concept="1" trace="TestContext#(Lorg/jetbrains/mps/openapi/model/SModel;)V" />
+      <node id="6547494638219647278" at="27,0,31,0" concept="1" trace="TestGenContext#(Lorg/jetbrains/mps/openapi/model/SModel;)V" />
+      <node id="6547494638219647311" at="31,0,35,0" concept="4" trace="putSessionObject#(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;" />
+      <node id="6547494638219647301" at="35,0,39,0" concept="4" trace="getSessionObject#(Ljava/lang/Object;)Ljava/lang/Object;" />
+      <node id="6547494638219647510" at="39,0,43,0" concept="4" trace="getOriginalCopiedInputNode#(Lorg/jetbrains/mps/openapi/model/SNode;)Lorg/jetbrains/mps/openapi/model/SNode;" />
+      <node id="6547494638219647376" at="43,0,47,0" concept="4" trace="getOriginalInputModel#()Lorg/jetbrains/mps/openapi/model/SModel;" />
+      <node id="6547494638219647490" at="47,0,51,0" concept="4" trace="getCopiedOutputNodeForInputNode#(Lorg/jetbrains/mps/openapi/model/SNode;)Lorg/jetbrains/mps/openapi/model/SNode;" />
+      <node id="6547494638219647662" at="51,0,55,0" concept="4" trace="getRuleNode#()Lorg/jetbrains/mps/openapi/model/SNodeReference;" />
+      <node id="6547494638219647655" at="55,0,59,0" concept="4" trace="getTemplateNodeRef#()Lorg/jetbrains/mps/openapi/model/SNodeReference;" />
+      <node id="6547494638219647642" at="59,0,63,0" concept="4" trace="showErrorMessage#(Lorg/jetbrains/mps/openapi/model/SNode;Ljava/lang/String;)V" />
+      <node id="6547494638219647629" at="63,0,67,0" concept="4" trace="showWarningMessage#(Lorg/jetbrains/mps/openapi/model/SNode;Ljava/lang/String;)V" />
+      <node id="6547494638219647616" at="67,0,71,0" concept="4" trace="showInformationMessage#(Lorg/jetbrains/mps/openapi/model/SNode;Ljava/lang/String;)V" />
+      <node id="6547494638219647606" at="71,0,75,0" concept="4" trace="getStepObject#(Ljava/lang/Object;)Ljava/lang/Object;" />
+      <node id="6547494638219647593" at="75,0,79,0" concept="4" trace="putStepObject#(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;" />
+      <node id="6547494638219647583" at="79,0,83,0" concept="4" trace="getGenerationParameter#(Ljava/lang/String;)Ljava/lang/Object;" />
+      <node id="6547494638219647573" at="83,0,87,0" concept="4" trace="getPatternVariable#(Ljava/lang/String;)Ljava/lang/Object;" />
+      <node id="6547494638219647563" at="87,0,91,0" concept="4" trace="getVariable#(Ljava/lang/String;)Ljava/lang/Object;" />
+      <node id="6547494638219647553" at="91,0,95,0" concept="4" trace="getTransientObject#(Ljava/lang/Object;)Ljava/lang/Object;" />
+      <node id="6547494638219647540" at="95,0,99,0" concept="4" trace="putTransientObject#(Ljava/lang/Object;Ljava/lang/Object;)Ljava/lang/Object;" />
+      <node id="6547494638219647520" at="99,0,103,0" concept="4" trace="createUniqueName#(Ljava/lang/String;Lorg/jetbrains/mps/openapi/model/SNode;)Ljava/lang/String;" />
+      <node id="6547494638219647500" at="103,0,107,0" concept="4" trace="getPreviousInputNodeByMappingLabel#(Ljava/lang/String;)Lorg/jetbrains/mps/openapi/model/SNode;" />
+      <node id="6547494638219647458" at="107,0,111,0" concept="4" trace="registerMappingLabel#(Lorg/jetbrains/mps/openapi/model/SNode;Ljava/lang/String;Lorg/jetbrains/mps/openapi/model/SNode;)V" />
+      <node id="6547494638219647444" at="111,0,115,0" concept="4" trace="getAllOutputNodesByInputNodeAndMappingLabel#(Lorg/jetbrains/mps/openapi/model/SNode;Ljava/lang/String;)Ljava/util/List;" />
+      <node id="6547494638219647414" at="115,0,119,0" concept="4" trace="getOutputNodeByInputNodeAndMappingLabel#(Lorg/jetbrains/mps/openapi/model/SNode;Ljava/lang/String;)Lorg/jetbrains/mps/openapi/model/SNode;" />
+      <node id="6547494638219647390" at="119,0,123,0" concept="4" trace="getGenerator#()Ljetbrains/mps/generator/template/ITemplateGenerator;" />
+      <node id="6547494638219647369" at="123,0,127,0" concept="4" trace="getOutputModel#()Lorg/jetbrains/mps/openapi/model/SModel;" />
+      <node id="6547494638219647352" at="127,0,131,0" concept="4" trace="getInputModel#()Lorg/jetbrains/mps/openapi/model/SModel;" />
+      <node id="6547494638219647345" at="131,0,135,0" concept="4" trace="getOutputNode#()Lorg/jetbrains/mps/openapi/model/SNode;" />
+      <node id="6547494638219647331" at="135,0,139,0" concept="4" trace="getInputNode#()Lorg/jetbrains/mps/openapi/model/SNode;" />
       <scope id="5584673629410321151" at="20,43,21,44" />
       <scope id="6547494638219647318" at="32,56,33,27" />
       <scope id="6547494638219647306" at="36,46,37,24" />


### PR DESCRIPTION
Currently, `new RelativePathHelper("a/b/c/d/../..").makeRelative("a/b/c/d")` returns `../..` which is incorrect.

Since `a/b/c/d/../..` is equivalent to `a/b`, the correct relative path from `a/b/c/d/../..` to `a/b/c/d` is `c/d`. This pull request fixes this problem and adds a few tests.